### PR TITLE
Add support for opt-in/ opt-out scenarios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 os:
   - linux
-sudo: false
-addons:
-  apt:
-    # Flutter depends on /usr/lib/x86_64-linux-gnu/libstdc++.so.6 version GLIBCXX_3.4.18
-    sources:
-      - ubuntu-toolchain-r-test # if we don't specify this, the libstdc++6 we get is the wrong version
-    packages:
-      - libstdc++6
-      - fonts-droid
-before_script:
-  - git clone https://github.com/flutter/flutter.git
-  - ./flutter/bin/flutter doctor
+language: minimal
+env:
+  global:
+  - FLUTTER_HOME=$HOME/flutter
+
+before_install:
+- export PATH="$PATH:$FLUTTER_HOME/bin"
+- git clone https://github.com/flutter/flutter.git -b stable --depth=1 $FLUTTER_HOME
+- flutter config --no-analytics
+- flutter doctor -v
+install:
+- flutter pub get
 script:
-  - ./flutter/bin/flutter test
+- flutter test test
 cache:
   directories:
-    - $HOME/.pub-cache
+  - "$HOME/.pub-cache"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,40 +1,53 @@
 # Versions
 
+## 5.2.0+3
+
+- Add support for opt-in/ opt-out scenarios
+- Fix typo in constant AF_VALIDATE_PURCHASE
+
 ## 5.2.0+2
-- added default values to `initSdk` params 
+
+- added default values to `initSdk` params
 
 ## 5.2.0+1
+
 - Removed the use of RxDart
 - Checked that the streams are not closed before sending events
 
 ## 5.2.0
+
 - AppsFlyer sdk version is updated to v5.2.0
 - Switched `StreamController` to `BehaviourSubject` to fix bad state related to unclosed streams
 
 ## 1.2.5
+
 - `initSdk` now uses Future.delayed
 - Fixed iOS error in `initSdk` returned String instead of Map
 
 ## 1.2.3
-- Updated the README.
+
+- Updated the README
 - `initSdk` function now uses named parameters
 
 ## 1.2.2
+
 - Updated AppsFlyer SDK version:
-    - Android: v5.1.1
-    - iOS: v5.1.0
+  - Android: v5.1.1
+  - iOS: v5.1.0
 - Added `getSdkVersion` to the api
 - Changed `initSdk` to return a dynamic map
 
 ## 1.1.3
+
 - Added getAppsFlyerUID function to get a device unique user id
   
-## 1.1.2 
+## 1.1.2
+
 - Updated appsflyer framework to 4.9.0
 
 ## 1.1.0
-- Added the following functions:
 
+- Added the following functions:
   - `Stream validateAndTrackInAppPurchase( String publicKey, String signature, String purchaseData, String price, String currency, Map<String, String> additionalParameters)`
   - `void updateServerUninstallToken(String token)`
   - `Future<String> getHostPrefix()`

--- a/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
+++ b/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
@@ -11,6 +11,7 @@ import com.appsflyer.AppsFlyerConversionListener;
 import com.appsflyer.AppsFlyerInAppPurchaseValidatorListener;
 import com.appsflyer.AppsFlyerLib;
 import com.appsflyer.AppsFlyerProperties;
+import com.appsflyer.AppsFlyerTrackingRequestListener;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -306,7 +307,7 @@ public class AppsflyerSdkPlugin implements MethodCallHandler, FlutterPlugin, Act
         AppsFlyerLib.getInstance().setHost(hostPrefix, hostName);
     }
 
-    private void initSdk(MethodCall call, MethodChannel.Result result) {
+    private void initSdk(MethodCall call, final MethodChannel.Result result) {
         AppsFlyerConversionListener gcdListener = null;
         AppsFlyerLib instance = AppsFlyerLib.getInstance();
 
@@ -332,12 +333,19 @@ public class AppsflyerSdkPlugin implements MethodCallHandler, FlutterPlugin, Act
 
         instance.init(afDevKey, gcdListener, mContext);
         instance.trackEvent(mContext, null, null);
-        instance.startTracking(mApplication);
+        instance.startTracking(mApplication, afDevKey, new AppsFlyerTrackingRequestListener() {
+            @Override
+            public void onTrackingRequestSuccess() {
+                final Map<String, String> response = new HashMap<>();
+                response.put("status", "OK");
+                result.success(response);
+            }
 
-        final Map<String, String> response = new HashMap<>();
-        response.put("status", "OK");
-
-        result.success(response);
+            @Override
+            public void onTrackingRequestFailure(String s) {
+                result.error(s,null,null);
+            }
+        });
     }
 
     private void trackEvent(MethodCall call, MethodChannel.Result result) {

--- a/example/.flutter-plugins-dependencies
+++ b/example/.flutter-plugins-dependencies
@@ -1,1 +1,0 @@
-{"_info":"// This is a generated file; do not edit or check into version control.","dependencyGraph":[{"name":"appsflyer_sdk","dependencies":[]}]}

--- a/ios/Classes/AppsflyerSdkPlugin.m
+++ b/ios/Classes/AppsflyerSdkPlugin.m
@@ -208,11 +208,18 @@
     [AppsFlyerTracker sharedTracker].appleAppID = appId;
     [AppsFlyerTracker sharedTracker].appsFlyerDevKey = devKey;
     [AppsFlyerTracker sharedTracker].isDebug = isDebug;
-    [[AppsFlyerTracker sharedTracker] trackAppLaunch];
+    [[AppsFlyerTracker sharedTracker] trackAppLaunchWithCompletionHandler:^(NSDictionary<NSString *,id> *dictionary, NSError *error) {
+        if (error) {
+            result([FlutterError errorWithCode:error.description message:nil details:nil]);
+            return;
+        }
+        if (dictionary) {
+            result(@{@"status": @"OK"});
+            return;
+        }
+    }];
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appDidBecomeActive) name:UIApplicationDidBecomeActiveNotification object:nil];
-    
-    result(@{@"status": @"OK"});
 }
 
 -(void)trackEventWithCall:(FlutterMethodCall*)call result:(FlutterResult)result{
@@ -260,4 +267,3 @@
 
 
 @end
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: appsflyer_sdk
 description: A Flutter plugin for AppsFlyer SDK. Supports iOS and Android.
-version: 5.2.0+2
+version: 5.2.0+3
 homepage: https://github.com/AppsFlyerSDK/flutter_appsflyer_sdk
 
 environment:

--- a/test/appsflyer_sdk_test.dart
+++ b/test/appsflyer_sdk_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   AppsflyerSdk instance;
 
   group('AppsFlyerSdk', () {
@@ -20,7 +22,7 @@ void main() {
       log.clear();
 
       //test map options way
-      instance = AppsflyerSdk.private(methodChannel,eventChannel,
+      instance = AppsflyerSdk.private(methodChannel, eventChannel,
           mapOptions: {'afDevKey': 'sdfhj2342cx'});
     });
 
@@ -34,7 +36,10 @@ void main() {
         return 'FAIL';
       });
 
-      dynamic res = await instance.initSdk(true,true);
+      dynamic res = await instance.initSdk(
+        registerConversionDataCallback: true,
+        registerOnAppOpenAttributionCallback: true,
+      );
       expect(res, 'SUCCESS');
     });
   });


### PR DESCRIPTION
This PR adds callbacks to startTracking/ trackAppLaunch to facilitate opt-in/ opt-out scenarios as described in https://support.appsflyer.com/hc/en-us/articles/360001422989-Implementing-app-user-opt-in-opt-out-in-the-AppsFlyer-SDK.