### PR TITLE
Missing break in setSharingFilterForAllPartners

### DIFF
--- a/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
+++ b/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
@@ -137,6 +137,7 @@ public class AppsflyerSdkPlugin implements MethodCallHandler, FlutterPlugin, Act
                 break;
             case "setSharingFilterForAllPartners":
                 setSharingFilterForAllPartners(result);
+                break;
             default:
                 result.notImplemented();
                 break;


### PR DESCRIPTION
setSharingFilterForAllPartners emits two different results. The call always fails.