### PR TITLE
Add missing callback in ios setAppInviteOneLinkId method

### DIFF
--- a/ios/Classes/AppsflyerSdkPlugin.m
+++ b/ios/Classes/AppsflyerSdkPlugin.m
@@ -148,6 +148,11 @@
 - (void)setAppInviteOneLinkID:(FlutterMethodCall*)call result:(FlutterResult)result{
     NSString* oneLinkID = call.arguments[@"oneLinkID"];
     [AppsFlyerLib shared].appInviteOneLinkID = oneLinkID;
+    if([self->callbackById containsObject:@"successSetAppInviteOneLinkID"]){
+        [self->_callbackChannel invokeMethod:@"callListener" arguments:@{
+            @"id": @"successSetAppInviteOneLinkID"
+        }];
+    }
     result(nil);
 }
 


### PR DESCRIPTION
Hello!

In our company we have a use case that needs to setUp setAppInviteOneLinkId but this method is not working in iOS since callback is never executed.

**To Reproduce**
With this snippet:

![image](https://user-images.githubusercontent.com/4395258/99549043-8ca14580-29b9-11eb-8877-270f5744c0cc.png)

App in iOS will never generateInviteLink but is working in Android since java code is calling the callback function. 

In this PR we just fixed calling the callback but we're not sure if you guys want to have this method with a callback since the change of appInviteOneLinkId is a sync task.

Thank you guys for the work in the flutter plugin!
