### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ appsflyerSdk.initSdk(
 
 ## <a id="guides"> **📖 Guides**
 
-Great installation and setup guides can be viewed [here](/doc/Guides.md)
+Great installation and setup guides can be viewed [here](https://github.com/AppsFlyerSDK/appsflyer-flutter-plugin/blob/master/doc/Guides.md)
 
 ## <a id="api"> **📑 API**
 
-see the full [API](/doc/API.md) available for this plugin.
+see the full [API](https://github.com/AppsFlyerSDK/appsflyer-flutter-plugin/blob/master/doc/API.md) available for this plugin.


### PR DESCRIPTION
Links are not accessible from pub.dev site

Their destinations are currently: "https://github.com/doc/API.md" and "https://github.com/doc/Guides.md"

<img width="580" alt="Screen Shot 2021-02-25 at 13 46 26" src="https://user-images.githubusercontent.com/46875013/109142681-368a2e00-7770-11eb-9124-220db5db6477.png">
