### PR TITLE
generateInviteLink error fixed

### DIFF
--- a/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
+++ b/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
@@ -302,14 +302,14 @@ public class AppsflyerSdkPlugin implements MethodCallHandler, FlutterPlugin, Act
             @Override
             public void onResponse(final String oneLinkUrl) {
                 if (mCallbacks.containsKey("successGenerateInviteLink")) {
-//                    runOnUIThread(oneLinkUrl, "successGenerateInviteLink", AF_SUCCESS);
+                   runOnUIThread(oneLinkUrl, "successGenerateInviteLink", AF_SUCCESS);
                 }
             }
 
             @Override
             public void onResponseError(final String error) {
                 if (mCallbacks.containsKey("errorGenerateInviteLink")) {
-//                    runOnUIThread(error, "errorGenerateInviteLink", AF_FAILURE);
+                   runOnUIThread(error, "errorGenerateInviteLink", AF_FAILURE);
                 }
             }
         };

--- a/lib/src/callbacks.dart
+++ b/lib/src/callbacks.dart
@@ -13,7 +13,12 @@ Future<void> _methodCallHandler(MethodCall call) async {
   switch (call.method) {
     case 'callListener':
       try {
-        dynamic callMap = jsonDecode(call.arguments);
+        dynamic callMap;
+        if (call.arguments is String) {
+          callMap = jsonDecode(call.arguments);
+        } else {
+          callMap = call.arguments;
+        }
         switch (callMap["id"]) {
           case "onAppOpenAttribution":
           case "onInstallConversionData":
@@ -27,7 +32,7 @@ Future<void> _methodCallHandler(MethodCall call) async {
             _callbacksById[callMap["id"]](fullResponse);
             break;
           default:
-            _callbacksById[call.arguments["id"]](call.arguments["data"]);
+            _callbacksById[callMap["id"]](callMap["data"]);
             break;
         }
       } catch (e) {


### PR DESCRIPTION
generateInviteLink method had an error both in iOS and Android.

error in iOS:
> flutter: type '_InternalLinkedHashMap<dynamic, dynamic>' is not a subtype of type 'String'
> flutter: #0      _methodCallHandler (package:appsflyer_sdk/src/callbacks.dart:16:43)
> #1      MethodChannel._handleAsMethodCall (package:flutter/src/services/platform_channel.dart:430:55)
> #2      MethodChannel.setMethodCallHandler.<anonymous closure> (package:flutter/src/services/platform_channel.dart:383:34)
> #3      _DefaultBinaryMessenger.handlePlatformMessage (package:flutter/src/services/binding.dart:283:33)
> #4      _invoke3.<anonymous closure> (dart:ui/hooks.dart:280:15)
> #5      _rootRun (dart:async/zone.dart:1190:13)
> #6      _CustomZone.run (dart:async/zone.dart:1093:19)
> #7      _CustomZone.runGuarded (dart:async/zone.dart:997:7)
> #8      _invoke3 (dart:ui/hooks.dart:279:10)
> #9      _dispatchPlatformMessage (dart:ui/hooks.dart:154:5)

problem in Android:
Nothing happened even though the 'generateInviteLink' method invoked.
Because the essential line of code had commented out.
https://github.com/AppsFlyerSDK/appsflyer-flutter-plugin/commit/3f33127a467470151fd6edda1d7f9763c1190bfb#diff-9b0456635121c1f7a76eaf23dd10a14478f1e45ce19d92ed21d34710ef0ca5e0R284


Solution:
- Uncommented the android part of code (android problem fixed)
- Decode json string to dart Map only if the argument variable is string (iOS problem fixed)