### PR TITLE
Update Documentation

### DIFF
--- a/doc/Guides.md
+++ b/doc/Guides.md
@@ -49,7 +49,6 @@ appsflyerSdk = AppsflyerSdk(appsFlyerOptions);
 
 ```dart
 import 'dart:async';
-import 'dart:io';
 
 import 'package:package_info/package_info.dart';
 
@@ -214,7 +213,6 @@ class AppsFlyerService {
 
 ```dart
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 
@@ -276,7 +274,7 @@ Navigate to our website and set up a OneLink template. Under the "when app is in
 #### Flutter Setup
 In your app’s manifest (`android/app/src/main/AndroidManifest.xml`) add the intent-filter you received from the above AppsFlyer step to your relevant activity:
 ```xml 
- <intent-filter  android:autoVerify="true">
+<intent-filter  android:autoVerify="true">
     <action android:name="android.intent.action.VIEW" />
     <category android:name="android.intent.category.DEFAULT" />
     <category android:name="android.intent.category.BROWSABLE" />

--- a/doc/Guides.md
+++ b/doc/Guides.md
@@ -271,6 +271,10 @@ class AppsFlyerService {
 #### AppsFlyer Setup
 Navigate to our website and set up a OneLink template. Under the "when app is installed" section, configure Android to launch the app using Universal links. 
 
+Get your SHA256 fingerprint
+1. [Creating A Keystore](https://flutter.dev/docs/deployment/android#create-a-keystore) (you'll eventually need to do this to release on the Play Store)
+2. [Generate Fingerprint](https://developers.google.com/android/guides/client-auth)
+
 #### Flutter Setup
 In your app’s manifest (`android/app/src/main/AndroidManifest.xml`) add the intent-filter you received from the above AppsFlyer step to your relevant activity:
 ```xml 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,6 +9,8 @@ description: Demonstrates how to use the appsflyer_sdk plugin.
 # Read more about versioning at semver.org.
 version: 1.0.0+1
 
+publish_to: none
+
 environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,8 +10,7 @@ description: Demonstrates how to use the appsflyer_sdk plugin.
 version: 1.0.0+1
 
 environment:
-  flutter: ">=2.0.0 < 3.0.0"
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.0.0-dev.68.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -10,7 +10,8 @@ description: Demonstrates how to use the appsflyer_sdk plugin.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  flutter: ">=2.0.0 < 3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
### Proposed Changes
#### Example App
- Remove warning from pubspec.yaml by making sure the example app isn't able to be published

#### Guildes.md
- Clarify where to get your Team Id required for iOS OneLink connection through the AppsFlyer website (L311-L317)
- Clarify how to generate the SHA256 needed for Android OneLink connection through the AppsFlyer website (L271-L279)
- Remove unnecessary setup for iOS that Flutter takes care of for you (double check me on this but my deep link worked without additional setup)
- Add explicit typing to functions
- Clarify where to get the `afAppId`
- Update the `isDebug` value to pull from the `kDebugMode` constant found in the `package:flutter/foundation.dart` file
- Specify the use of `flutter_dotenv` (or similar) to remove the devKey from source control
- Create a full example using [Dart's Cascade Notation](https://dart.dev/guides/language/language-tour#cascade-notation) to call functions on the `appsFlyerSdk`

### Help
Flutter defaults to `Kotlin`, but the guide only uses `Java`. Would you be able to update the guide with the `Kotlin` alternative? (L301-L304)