### PR TITLE
v7: Implement Type Safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,30 @@ When submitting an issue please specify your AppsFlyer sign-up (account) email ,
 
 - Android AppsFlyerSDK **v6.2.0**
 
+### Type Safety Introduced from version `7.0.0`, upgraded from `Map` and `dynamic` types!
+
 ### Flutter 2.0 is supported from version `6.2.3+2`, including null safety support!
 
 ### The version `6.2.4-flutterv1` will use iOS SDK V6.2.4 with Flutter V1
 
 ---
+
+## <a id="v7-breaking-changes"> **❗Migration Guide to v7**
+With the introduction of type safety, we've fully revamped the way we return data! We've given you tools to interact with those types as well.
+
+Before version 7, your callbacks would receive `dynamic` data and you'd have to do the leg work yourself. Now, in v7, we classes containing 
+the information you're looking for. In the case of deep links, we provide classes you can use to convert our `Map`s to.
+
+### Quick Start
+Use the `AppsFlyerService` from the example app to get started!
+
+### Rather Do It Yourself?
+Use the `map` or `when` method in combination with `OneLinkBase.fromJson` on any `AppsFlyerResponse` to handle the payload returned.
+
+Alternatively, check out the `DeepLinkResponse` class within the service to see how to create your own class with custom params.
+
 ## <a id="v6-breaking-changes"> **❗Migration Guide to v6**
-- [Integration guide](https://support.appsflyer.com//hc/en-us/articles/207032066#introduction)
+- [Integration guide](https://support.appsflyer.com/hc/en-us/articles/207032066#introduction)
 - [Migration guide](https://support.appsflyer.com/hc/en-us/articles/360011571778)
 
 In v6 of AppsFlyer SDK there are some api breaking changes: 
@@ -67,7 +84,7 @@ In order to install the plugin, visit [this](https://pub.dartlang.org/packages/a
 
 ### <a id="appsFlyer-options"> ⚙️  AppsFlyerOptions
 
-To start using AppsFlyer you first need to create an instance of `AppsflyerSdk` before using any other of our sdk functionalities.  
+To start using AppsFlyer you first need to create an instance of `AppsflyerSdk` before using any other of our sdk functionalities (see the service in the example app for v7 and above).  
 
 `AppsflyerSdk` receives a map or `AppsFlyerOptions` object. This is how you can configure our `AppsflyerSdk` instance and connect it to your AppsFlyer account.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ When submitting an issue please specify your AppsFlyer sign-up (account) email ,
 
 - Android AppsFlyerSDK **v6.2.0**
 
-### Flutter 2.0 is supported from V6.2.3+2, including null safety support!
+### Flutter 2.0 is supported from version `6.2.3+2`, including null safety support!
 
 ### The version `6.2.4-flutterv1` will use iOS SDK V6.2.4 with Flutter V1
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ When submitting an issue please specify your AppsFlyer sign-up (account) email ,
 
 ### Flutter 2.0 is supported from V6.2.3+2, including null safety support!
 
+### The version `6.2.4-flutterv1` will use iOS SDK V6.2.4 with Flutter V1
+
 ---
 ## <a id="v6-breaking-changes"> **❗Migration Guide to v6**
 - [Integration guide](https://support.appsflyer.com//hc/en-us/articles/207032066#introduction)

--- a/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
+++ b/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
@@ -203,7 +203,7 @@ public class AppsflyerSdkPlugin implements MethodCallHandler, FlutterPlugin, Act
                 generateInviteLink(call, result);
                 break;
             case "setAppInviteOneLinkID":
-                setAppInivteOneLinkID(call, result);
+                setAppInviteOneLinkID(call, result);
                 break;
             case "logCrossPromotionImpression":
                 logCrossPromotionImpression(call, result);
@@ -270,7 +270,7 @@ public class AppsflyerSdkPlugin implements MethodCallHandler, FlutterPlugin, Act
         result.success(null);
     }
 
-    private void setAppInivteOneLinkID(MethodCall call, Result result) {
+    private void setAppInviteOneLinkID(MethodCall call, Result result) {
         String oneLinkId = (String) call.argument("oneLinkID");
         if(oneLinkId==null || oneLinkId.length() == 0){
             result.success(null);

--- a/example/README.md
+++ b/example/README.md
@@ -10,3 +10,33 @@ $ flutter run
 ```
 
 ![demo printscreen](assets/demo_example.png?raw=true)
+
+# How to Use Your Dashboard
+
+1. Update the `.env` file with your values:
+
+```bash
+DEV_KEY="your dev key" # via Website Configuration Settings: https://hq1.appsflyer.com/account/api-tokens
+ANDROID_APP_ID="com.domain.andoidApp"
+IOS_APP_ID="com.domain.iosapp"
+```
+
+2. Update the intent filter on Android
+Location: android > app > src > main > AndroidManifest.xml
+
+```xml
+<!-- start appsflyer_sdk -->
+<!-- Get your apps configuration from the AppsFlyer Dashboard --> 
+<!-- OneLink Template: "When app is installed" > Launching the app using Android App Links > Save Changes -->
+<intent-filter  android:autoVerify="true">
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data android:scheme="https"
+        android:host="yourcompany.onelink.me"
+        android:pathPrefix="yourPrefix" /> 
+</intent-filter>
+<!-- end appsflyer_sdk -->
+```
+
+3. Reload the app (stop the debugger)

--- a/example/lib/app_constants.dart
+++ b/example/lib/app_constants.dart
@@ -1,4 +1,4 @@
 class AppConstants {
-  static const double TOP_PADDING = 12.0;
-  static const double CONTAINER_PADDING = 8.0;
+  static const double topPadding = 12.0;
+  static const double containerPadding = 8.0;
 }

--- a/example/lib/appsflyer_service.dart
+++ b/example/lib/appsflyer_service.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:appsflyer_sdk/appsflyer_sdk.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+class AppsFlyerService extends ChangeNotifier {
+  // full app restart required when changing static variables
+  static const brandDomain = 'sub.domain.com';
+  static const urlPrefix = 'https://$brandDomain';
+
+  final Completer _sdkInitialized = Completer();
+
+  AppsflyerSdk sdk;
+  AppInstallResponse appInstallResponse;
+  DeepLinkResponse deepLinkData;
+
+  Future get initializer => _sdkInitialized.future;
+
+  Future<void> initialize() async {
+    // Set these values in the .env file
+    final dotEnv = DotEnv();
+    final devKey = dotEnv.env['DEV_KEY'];
+    final appKey = Platform.isIOS ? 'IOS_APP_ID' : 'ANDROID_APP_ID';
+    final appId = dotEnv.env[appKey];
+
+    final options = AppsFlyerOptions(
+      afDevKey: devKey,
+      appId: appId,
+      showDebug: true,
+    );
+
+    sdk = AppsflyerSdk(options)
+      ..onInstallConversionData(_handleInstallConversion)
+      ..onAppOpenAttribution(_handleDeepLink)
+      ..onDeepLinking(_handleDeepLink);
+
+    _sdkInitialized.complete();
+  }
+
+  void dispose() {
+    sdk?.dispose();
+    super.dispose();
+  }
+
+  void _handleInstallConversion(AppsFlyerResponse response) {
+    debugPrint('Install conversion response: $response');
+
+    final appInstallResponse = response.map(_toAppInstallResponse);
+
+    this.appInstallResponse = appInstallResponse;
+    notifyListeners();
+  }
+
+  void _handleDeepLink(AppsFlyerResponse response) {
+    debugPrint('Deep link response: $response');
+
+    final deepLinkData = response.map(_toDeepLinkResponse);
+
+    this.deepLinkData = deepLinkData;
+    notifyListeners();
+  }
+
+  AppInstallResponse _toAppInstallResponse(json) {
+    // Note: `json` can be null
+    if (json != null) return AppInstallResponse.fromJson(json);
+
+    return null;
+  }
+
+  DeepLinkResponse _toDeepLinkResponse(json) {
+    // Note: `json` can be null
+    if (json != null) return DeepLinkResponse.fromJson(json);
+
+    return null;
+  }
+
+  Future<AppsFlyerResponse> getLinkAsync(AppsFlyerInviteLinkParams params) {
+    final completer = Completer<AppsFlyerResponse>();
+
+    sdk.generateInviteLink(
+      params,
+      onSuccess: (link) {
+        debugPrint('success: $link');
+        completer.complete(link);
+      },
+      onError: (error) {
+        debugPrint('failure: $error');
+        completer.completeError(error);
+      },
+    );
+
+    return completer.future;
+  }
+}
+
+class DeepLinkResponse with Diagnosticable {
+  final OneLinkBase base;
+  // Add your custom attributes below here
+  final String product; // example attribute
+  final String branch; // example attribute
+
+  DeepLinkResponse._({
+    @required this.base,
+    @required this.product,
+    @required this.branch,
+  });
+
+  /// Convert JSON data to a [DeepLinkResponse]
+  static DeepLinkResponse fromJson(Map<String, dynamic> json) {
+    try {
+      final base = OneLinkBase.fromJson(json);
+      // Your custom attributes
+      final product = json['product'];
+      final branch = json['branch'];
+
+      final result = DeepLinkResponse._(
+        base: base,
+        product: product,
+        branch: branch,
+      );
+
+      debugPrint('$DeepLinkResponse created! $result');
+
+      return result;
+    } catch (e) {
+      debugPrint('$DeepLinkResponse creation failed: $e');
+    }
+
+    return null;
+  }
+
+  /// Prints the information below when [toString] is called
+  ///
+  /// Extremely helpful for debugging
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsNode.message('$base'));
+    // Your custom attributes
+    properties.add(DiagnosticsNode.message('product: $product'));
+    properties.add(DiagnosticsNode.message('branch: $branch'));
+  }
+}

--- a/example/lib/appsflyer_service.dart
+++ b/example/lib/appsflyer_service.dart
@@ -76,7 +76,8 @@ class AppsFlyerService extends ChangeNotifier {
     return null;
   }
 
-  Future<AppsFlyerResponse> getLinkAsync(AppsFlyerInviteLinkParams params) {
+  Future<AppsFlyerResponse> generateInviteLinkAsync(
+      AppsFlyerInviteLinkParams params) {
     final completer = Completer<AppsFlyerResponse>();
 
     sdk.generateInviteLink(

--- a/example/lib/home_container.dart
+++ b/example/lib/home_container.dart
@@ -1,15 +1,19 @@
-import 'dart:async';
+import 'package:appsflyer_sdk/appsflyer_sdk.dart';
 import 'package:flutter/material.dart';
+
 import './app_constants.dart';
+import 'appsflyer_service.dart';
 import 'text_border.dart';
 import 'utils.dart';
 
 class HomeContainer extends StatefulWidget {
-  final Map<String, dynamic> onData;
-  final Future<bool> Function(String, Map<String, dynamic>) logEvent;
-  final Object deepLinkData;
+  final AppsFlyerService appsFlyerService;
+  final DeepLinkResponse deepLinkData;
+  final AppInstallResponse appInstallData;
 
-  HomeContainer({this.onData, this.deepLinkData, this.logEvent});
+  HomeContainer({@required this.appsFlyerService})
+      : deepLinkData = appsFlyerService.deepLinkData,
+        appInstallData = appsFlyerService.appInstallResponse;
 
   @override
   _HomeContainerState createState() => _HomeContainerState();
@@ -23,105 +27,181 @@ class _HomeContainerState extends State<HomeContainer> {
     "af_revenue": "20"
   };
 
-  String _logEventResponse = "No event have been sent";
-  TextEditingController textEditingController;
+  TextEditingController inviteLinkController;
+  TextEditingController attributionController;
+  TextEditingController deepLinkController;
+  TextEditingController eventController;
+  TextEditingController responseController;
+
+  AppsflyerSdk get sdk => widget.appsFlyerService.sdk;
 
   @override
   void initState() {
     super.initState();
-    final text = widget.deepLinkData != null
-        ? Utils.formatJson(widget.deepLinkData)
-        : "No Attribution data";
+    final attributionData = widget.deepLinkData != null
+        ? Utils.prettyPrintDiagnosticable(widget.appInstallData)
+        : 'No attribution data';
+    final deepLinkData = widget.deepLinkData != null
+        ? Utils.prettyPrintDiagnosticable(widget.deepLinkData)
+        : 'No deep link data';
+    final eventData =
+        'event name: $eventName\nevent values: ${Utils.formatJson(eventValues)}';
+    final responseDefault = "No event has been sent";
+    final inviteLinkDefault = "No link has been generated";
 
-    textEditingController = TextEditingController(text: text);
+    inviteLinkController = TextEditingController(text: inviteLinkDefault);
+    attributionController = TextEditingController(text: attributionData);
+    deepLinkController = TextEditingController(text: deepLinkData);
+    eventController = TextEditingController(text: eventData);
+    responseController = TextEditingController(text: responseDefault);
   }
 
   @override
   void dispose() {
-    textEditingController?.dispose();
+    _disposeControllers();
     super.dispose();
+  }
+
+  void _disposeControllers() {
+    [
+      inviteLinkController,
+      attributionController,
+      deepLinkController,
+      eventController,
+      responseController,
+    ].forEach((controller) => controller?.dispose());
   }
 
   @override
   Widget build(BuildContext context) {
     return SingleChildScrollView(
-      child: Container(
-        child: Padding(
-          padding: EdgeInsets.all(AppConstants.CONTAINER_PADDING),
-          child: Column(
-            children: <Widget>[
-              Text(
-                "AF SDK",
-                style: TextStyle(fontWeight: FontWeight.bold),
+      child: Padding(
+        padding: EdgeInsets.all(AppConstants.CONTAINER_PADDING),
+        child: Column(
+          children: <Widget>[
+            Text("AF SDK", style: TextStyle(fontWeight: FontWeight.bold)),
+            Padding(padding: EdgeInsets.only(top: AppConstants.TOP_PADDING)),
+            SizedBox(height: 12.0),
+            TextBorder(
+              labelText: "Attribution Data:",
+              controller: attributionController,
+            ),
+            SizedBox(height: 12.0),
+            TextBorder(
+              labelText: "Deep Link Data:",
+              controller: deepLinkController,
+            ),
+            SizedBox(height: 12.0),
+            Container(
+              padding: EdgeInsets.all(20.0),
+              decoration: BoxDecoration(
+                border: Border.all(color: Colors.grey),
               ),
-              Padding(
-                padding: EdgeInsets.only(top: AppConstants.TOP_PADDING),
-              ),
-              TextBorder(
-                controller: TextEditingController(
-                    text: widget.onData != null
-                        ? Utils.formatJson(widget.onData)
-                        : "No conversion data"),
-                labelText: "Conversion Data:",
-              ),
-              Padding(
-                padding: EdgeInsets.only(top: 12.0),
-              ),
-              TextBorder(
-                controller: textEditingController,
-                labelText: "Attribution Data:",
-              ),
-              Padding(
-                padding: EdgeInsets.only(top: 12.0),
-              ),
-              Container(
-                padding: EdgeInsets.all(20.0),
-                decoration: BoxDecoration(
-                  border: Border.all(
-                    color: Colors.grey,
-                  ),
-                ),
-                child: Column(children: <Widget>[
-                  Center(
-                    child: Text("Log event"),
-                  ),
-                  Padding(
-                    padding: EdgeInsets.only(top: 12.0),
-                  ),
+              child: Column(
+                children: <Widget>[
+                  Center(child: Text("Log event")),
+                  SizedBox(height: 12.0),
                   TextBorder(
-                    controller: TextEditingController(
-                        text:
-                            "event name: $eventName\nevent values: $eventValues"),
                     labelText: "Event Request",
+                    controller: eventController,
                   ),
-                  Padding(
-                    padding: EdgeInsets.only(top: 12.0),
-                  ),
+                  SizedBox(height: 12.0),
                   TextBorder(
-                      labelText: "Server response",
-                      controller:
-                          TextEditingController(text: _logEventResponse)),
+                    labelText: "Server response",
+                    controller: responseController,
+                  ),
+                  SizedBox(height: 12.0),
                   ElevatedButton(
-                    onPressed: () {
-                      print("Pressed");
-                      widget.logEvent(eventName, eventValues).then((onValue) {
-                        setState(() {
-                          _logEventResponse = onValue.toString();
-                        });
-                      }).catchError((onError) {
-                        setState(() {
-                          _logEventResponse = onError.toString();
-                        });
-                      });
+                    onPressed: () async {
+                      print("Purchase Event Button Pressed");
+                      final value = await sdk.logEvent(
+                        eventName,
+                        eventValues,
+                      );
+
+                      responseController.text = value.toString();
                     },
                     child: Text("Send purchase event"),
                   ),
-                ]),
-              )
-            ],
-          ),
+                ],
+              ),
+            ),
+            _buildGenerateLinkSection(),
+          ],
         ),
       ),
+    );
+  }
+
+  Widget _buildGenerateLinkSection() {
+    return Container(
+      padding: EdgeInsets.all(20.0),
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.grey),
+      ),
+      child: Column(
+        children: <Widget>[
+          Center(child: Text("Generate Link")),
+          SizedBox(height: 12.0),
+          TextBorder(
+            labelText: "Invite Link",
+            controller: inviteLinkController,
+          ),
+          SizedBox(height: 12.0),
+          AsyncButton(
+            service: widget.appsFlyerService,
+            inviteLinkController: inviteLinkController,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class AsyncButton extends StatefulWidget {
+  final AppsFlyerService service;
+  final TextEditingController inviteLinkController;
+
+  const AsyncButton({
+    @required this.service,
+    @required this.inviteLinkController,
+    Key key,
+  }) : super(key: key);
+
+  @override
+  _AsyncButtonState createState() => _AsyncButtonState();
+}
+
+class _AsyncButtonState extends State<AsyncButton> {
+  bool isBusy = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: isBusy
+          ? null
+          : () async {
+              setState(() => isBusy = true);
+              print("Generate Invite Link");
+              final params = AppsFlyerInviteLinkParams(
+                baseDeepLink: 'sub.onelink.me',
+                brandDomain: 'sub.domain.com',
+                campaign: 'Your Campaign Name',
+                customerID: 'Generated Link Campaign',
+                referreImageUrl:
+                    r'https://cdn.appsflyer.com/af-libs/fe-components-global/4.3.41/af-logo-white.21a9ef88fd066e8acf2c1e3af4d46dd3.png',
+                referrerName: 'Mobile App',
+              );
+
+              final value = await widget.service.getLinkAsync(params);
+
+              value.map(
+                (x) => widget.inviteLinkController.text =
+                    Utils.prettyPrintDiagnosticable(value),
+              );
+              setState(() => isBusy = false);
+            },
+      child: isBusy ? Text("Generating Link...") : Text("Generate Invite Link"),
     );
   }
 }

--- a/example/lib/home_container.dart
+++ b/example/lib/home_container.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:appsflyer_sdk/appsflyer_sdk.dart';
 import 'package:flutter/material.dart';
 
@@ -20,11 +22,11 @@ class HomeContainer extends StatefulWidget {
 }
 
 class _HomeContainerState extends State<HomeContainer> {
-  final String eventName = "purchase";
+  final String eventName = 'purchase';
   final Map<String, String> eventValues = {
-    "af_content_id": "id123",
-    "af_currency": "USD",
-    "af_revenue": "20"
+    'af_content_id': 'id123',
+    'af_currency': 'USD',
+    'af_revenue': '20'
   };
 
   TextEditingController inviteLinkController;
@@ -46,8 +48,8 @@ class _HomeContainerState extends State<HomeContainer> {
         : 'No deep link data';
     final eventData =
         'event name: $eventName\nevent values: ${Utils.formatJson(eventValues)}';
-    final responseDefault = "No event has been sent";
-    final inviteLinkDefault = "No link has been generated";
+    final responseDefault = 'No event has been sent';
+    final inviteLinkDefault = 'No link has been generated';
 
     inviteLinkController = TextEditingController(text: inviteLinkDefault);
     attributionController = TextEditingController(text: attributionData);
@@ -76,59 +78,67 @@ class _HomeContainerState extends State<HomeContainer> {
   Widget build(BuildContext context) {
     return SingleChildScrollView(
       child: Padding(
-        padding: EdgeInsets.all(AppConstants.CONTAINER_PADDING),
+        padding: EdgeInsets.all(AppConstants.containerPadding),
         child: Column(
           children: <Widget>[
-            Text("AF SDK", style: TextStyle(fontWeight: FontWeight.bold)),
-            Padding(padding: EdgeInsets.only(top: AppConstants.TOP_PADDING)),
+            Text('AF SDK', style: TextStyle(fontWeight: FontWeight.bold)),
+            Padding(padding: EdgeInsets.only(top: AppConstants.topPadding)),
             SizedBox(height: 12.0),
             TextBorder(
-              labelText: "Attribution Data:",
+              labelText: 'Attribution Data:',
               controller: attributionController,
             ),
             SizedBox(height: 12.0),
             TextBorder(
-              labelText: "Deep Link Data:",
+              labelText: 'Deep Link Data:',
               controller: deepLinkController,
             ),
             SizedBox(height: 12.0),
-            Container(
-              padding: EdgeInsets.all(20.0),
-              decoration: BoxDecoration(
-                border: Border.all(color: Colors.grey),
-              ),
-              child: Column(
-                children: <Widget>[
-                  Center(child: Text("Log event")),
-                  SizedBox(height: 12.0),
-                  TextBorder(
-                    labelText: "Event Request",
-                    controller: eventController,
-                  ),
-                  SizedBox(height: 12.0),
-                  TextBorder(
-                    labelText: "Server response",
-                    controller: responseController,
-                  ),
-                  SizedBox(height: 12.0),
-                  ElevatedButton(
-                    onPressed: () async {
-                      print("Purchase Event Button Pressed");
-                      final value = await sdk.logEvent(
-                        eventName,
-                        eventValues,
-                      );
-
-                      responseController.text = value.toString();
-                    },
-                    child: Text("Send purchase event"),
-                  ),
-                ],
-              ),
-            ),
+            _buildPurchaseEventSection(),
             _buildGenerateLinkSection(),
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildPurchaseEventSection() {
+    return Container(
+      padding: EdgeInsets.all(20.0),
+      decoration: BoxDecoration(
+        border: Border.all(color: Colors.grey),
+      ),
+      child: Column(
+        children: <Widget>[
+          Center(child: Text('Log event')),
+          SizedBox(height: 12.0),
+          TextBorder(
+            labelText: 'Event Request',
+            controller: eventController,
+          ),
+          SizedBox(height: 12.0),
+          TextBorder(
+            labelText: 'Server response',
+            controller: responseController,
+          ),
+          SizedBox(height: 12.0),
+          AsyncButton(
+            onPressed: () async {
+              print('Purchase Event Button Pressed');
+              final value = await sdk.logEvent(
+                eventName,
+                eventValues,
+              );
+
+              responseController.text = value.toString();
+            },
+            builder: (isBusy) {
+              return isBusy
+                  ? Text('Sending event...')
+                  : Text('Send Purchase Event');
+            },
+          ),
+        ],
       ),
     );
   }
@@ -141,30 +151,53 @@ class _HomeContainerState extends State<HomeContainer> {
       ),
       child: Column(
         children: <Widget>[
-          Center(child: Text("Generate Link")),
+          Center(child: Text('Generate Link')),
           SizedBox(height: 12.0),
           TextBorder(
-            labelText: "Invite Link",
+            labelText: 'Invite Link',
             controller: inviteLinkController,
           ),
           SizedBox(height: 12.0),
           AsyncButton(
-            service: widget.appsFlyerService,
-            inviteLinkController: inviteLinkController,
+            onPressed: _generateInviteLink,
+            builder: (isBusy) => isBusy
+                ? Text('Generating Link...')
+                : Text('Generate Invite Link'),
           ),
         ],
       ),
     );
   }
+
+  Future<void> _generateInviteLink() async {
+    debugPrint('Generating Invite Link');
+
+    final params = AppsFlyerInviteLinkParams(
+      baseDeepLink: 'sub.onelink.me',
+      brandDomain: 'sub.domain.com',
+      campaign: 'Your Campaign Name',
+      customerID: 'Generated Link Campaign',
+      referrerImageUrl:
+          r'https://cdn.appsflyer.com/af-libs/fe-components-global/4.3.41/af-logo-white.21a9ef88fd066e8acf2c1e3af4d46dd3.png',
+      referrerName: 'Mobile App',
+    );
+
+    final service = widget.appsFlyerService;
+    final appsFlyerResponse = await service.generateInviteLinkAsync(params);
+
+    inviteLinkController.text = Utils.prettyPrintDiagnosticable(
+      appsFlyerResponse,
+    );
+  }
 }
 
 class AsyncButton extends StatefulWidget {
-  final AppsFlyerService service;
-  final TextEditingController inviteLinkController;
+  final Future Function() onPressed;
+  final Widget Function(bool isBusy) builder;
 
   const AsyncButton({
-    @required this.service,
-    @required this.inviteLinkController,
+    @required this.onPressed,
+    @required this.builder,
     Key key,
   }) : super(key: key);
 
@@ -182,26 +215,10 @@ class _AsyncButtonState extends State<AsyncButton> {
           ? null
           : () async {
               setState(() => isBusy = true);
-              print("Generate Invite Link");
-              final params = AppsFlyerInviteLinkParams(
-                baseDeepLink: 'sub.onelink.me',
-                brandDomain: 'sub.domain.com',
-                campaign: 'Your Campaign Name',
-                customerID: 'Generated Link Campaign',
-                referreImageUrl:
-                    r'https://cdn.appsflyer.com/af-libs/fe-components-global/4.3.41/af-logo-white.21a9ef88fd066e8acf2c1e3af4d46dd3.png',
-                referrerName: 'Mobile App',
-              );
-
-              final value = await widget.service.getLinkAsync(params);
-
-              value.map(
-                (x) => widget.inviteLinkController.text =
-                    Utils.prettyPrintDiagnosticable(value),
-              );
+              await widget.onPressed();
               setState(() => isBusy = false);
             },
-      child: isBusy ? Text("Generating Link...") : Text("Generate Invite Link"),
+      child: widget.builder(isBusy),
     );
   }
 }

--- a/example/lib/home_container.dart
+++ b/example/lib/home_container.dart
@@ -80,10 +80,11 @@ class _HomeContainerState extends State<HomeContainer> {
       child: Padding(
         padding: EdgeInsets.all(AppConstants.containerPadding),
         child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            Text('AF SDK', style: TextStyle(fontWeight: FontWeight.bold)),
             Padding(padding: EdgeInsets.only(top: AppConstants.topPadding)),
-            SizedBox(height: 12.0),
+            InfoCard(),
+            SizedBox(height: 24),
             TextBorder(
               labelText: 'Attribution Data:',
               controller: attributionController,
@@ -95,7 +96,8 @@ class _HomeContainerState extends State<HomeContainer> {
             ),
             SizedBox(height: 12.0),
             _buildPurchaseEventSection(),
-            _buildGenerateLinkSection(),
+            SizedBox(height: 12.0),
+            LinkGenerator(appsFlyerService: widget.appsFlyerService),
           ],
         ),
       ),
@@ -142,8 +144,39 @@ class _HomeContainerState extends State<HomeContainer> {
       ),
     );
   }
+}
 
-  Widget _buildGenerateLinkSection() {
+class LinkGenerator extends StatefulWidget {
+  final AppsFlyerService appsFlyerService;
+
+  const LinkGenerator({
+    @required this.appsFlyerService,
+    Key key,
+  }) : super(key: key);
+
+  @override
+  _LinkGeneratorState createState() => _LinkGeneratorState();
+}
+
+class _LinkGeneratorState extends State<LinkGenerator> {
+  static const inviteLinkDefault = 'No link has been generated';
+  TextEditingController inviteLinkController;
+
+  @override
+  void initState() {
+    super.initState();
+
+    inviteLinkController = TextEditingController(text: inviteLinkDefault);
+  }
+
+  @override
+  void dispose() {
+    inviteLinkController?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Container(
       padding: EdgeInsets.all(20.0),
       decoration: BoxDecoration(
@@ -158,11 +191,21 @@ class _HomeContainerState extends State<HomeContainer> {
             controller: inviteLinkController,
           ),
           SizedBox(height: 12.0),
-          AsyncButton(
-            onPressed: _generateInviteLink,
-            builder: (isBusy) => isBusy
-                ? Text('Generating Link...')
-                : Text('Generate Invite Link'),
+          ButtonBar(
+            alignment: MainAxisAlignment.center,
+            children: [
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(primary: Colors.grey[700]),
+                onPressed: () => inviteLinkController.text = inviteLinkDefault,
+                child: Text('Clear'),
+              ),
+              AsyncButton(
+                onPressed: _generateInviteLink,
+                builder: (isBusy) => isBusy
+                    ? Text('Generating Link...')
+                    : Text('Generate Invite Link'),
+              ),
+            ],
           ),
         ],
       ),
@@ -182,11 +225,27 @@ class _HomeContainerState extends State<HomeContainer> {
       referrerName: 'Mobile App',
     );
 
-    final service = widget.appsFlyerService;
-    final appsFlyerResponse = await service.generateInviteLinkAsync(params);
+    final appsFlyerResponse =
+        await widget.appsFlyerService.generateInviteLinkAsync(params);
 
     inviteLinkController.text = Utils.prettyPrintDiagnosticable(
       appsFlyerResponse,
+    );
+  }
+}
+
+class InfoCard extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: Colors.grey[700],
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Text(
+          'Attribution and Deep Link data populate after opening a OneLink',
+          style: TextStyle(fontSize: 16, color: Colors.white),
+        ),
+      ),
     );
   }
 }

--- a/example/lib/home_container_streams.dart
+++ b/example/lib/home_container_streams.dart
@@ -33,7 +33,7 @@ class _HomeContainerStreamsState extends State<HomeContainerStreams> {
     return SingleChildScrollView(
       child: Container(
         child: Padding(
-          padding: EdgeInsets.all(AppConstants.CONTAINER_PADDING),
+          padding: EdgeInsets.all(AppConstants.containerPadding),
           child: Column(
             children: <Widget>[
               Text(
@@ -41,7 +41,7 @@ class _HomeContainerStreamsState extends State<HomeContainerStreams> {
                 style: TextStyle(fontWeight: FontWeight.bold),
               ),
               Padding(
-                padding: EdgeInsets.only(top: AppConstants.TOP_PADDING),
+                padding: EdgeInsets.only(top: AppConstants.topPadding),
               ),
               StreamBuilder<dynamic>(
                   stream: widget.onData?.asBroadcastStream(),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -13,8 +13,9 @@ Future<void> main() async {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return new MaterialApp(
-      home: new MainPage(),
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: MainPage(),
     );
   }
 }

--- a/example/lib/main_page.dart
+++ b/example/lib/main_page.dart
@@ -1,9 +1,7 @@
-import 'dart:async';
-import 'package:appsflyer_sdk/appsflyer_sdk.dart';
-import 'package:flutter/foundation.dart';
+import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 
+import 'appsflyer_service.dart';
 import 'home_container.dart';
 
 class MainPage extends StatefulWidget {
@@ -14,94 +12,48 @@ class MainPage extends StatefulWidget {
 }
 
 class MainPageState extends State<MainPage> {
-  AppsflyerSdk _appsflyerSdk;
-  Map<String, dynamic> _deepLinkData;
-  Map<String, dynamic> _gcd;
+  AppsFlyerService appsFlyerService;
 
-  // called on every foreground
   @override
   void initState() {
     super.initState();
-    final dotEnv = DotEnv();
-    final AppsFlyerOptions options = AppsFlyerOptions(
-      afDevKey: dotEnv.env["DEV_KEY"],
-      appId: dotEnv.env["APP_ID"],
-      showDebug: kDebugMode,
-    );
-
-    _appsflyerSdk = AppsflyerSdk(options)
-      ..onAppOpenAttribution(_handleAppOpenAttribution)
-      ..onInstallConversionData(_handleInstallConversionData)
-      ..onDeepLinking(_handleDeepLinking);
-  }
-
-  void _handleDeepLinking(AppsFlyerResponse response) {
-    print('res: $response');
-    setState(() {
-      _deepLinkData = response.then((data) {
-        return data;
-      });
-    });
-  }
-
-  void _handleInstallConversionData(AppsFlyerResponse response) {
-    print('res: $response');
-    setState(() {
-      _gcd = response.then((data) {
-        return data;
-      });
-    });
-  }
-
-  void _handleAppOpenAttribution(AppsFlyerResponse response) {
-    print('res: $response');
-    setState(() {
-      _deepLinkData = response.then((data) {
-        return data;
-      });
-    });
+    appsFlyerService = AppsFlyerService()..initialize();
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title: Column(
-            children: <Widget>[
-              Text('AppsFlyer SDK example app'),
-              FutureBuilder<String>(
-                future: _appsflyerSdk.getSDKVersion(),
-                builder: (BuildContext context, AsyncSnapshot snapshot) {
-                  return Text(snapshot.hasData ? snapshot.data : "");
-                },
-              ),
-            ],
-          ),
-        ),
-        body: FutureBuilder<dynamic>(
-            future: _appsflyerSdk.initSdk(
-              registerConversionDataCallback: true,
-              registerOnAppOpenAttributionCallback: true,
-              registerOnDeepLinkingCallback: true,
+      appBar: AppBar(
+        title: Column(
+          crossAxisAlignment: Platform.isAndroid
+              ? CrossAxisAlignment.start
+              : CrossAxisAlignment.center,
+          children: <Widget>[
+            Text('AppsFlyer SDK example app'),
+            FutureBuilder<String>(
+              future: appsFlyerService.sdk.getSDKVersion(),
+              builder: (BuildContext context, AsyncSnapshot snapshot) {
+                return Text(snapshot.hasData ? snapshot.data : "");
+              },
             ),
-            builder: (BuildContext context, AsyncSnapshot snapshot) {
-              if (snapshot.connectionState == ConnectionState.waiting) {
-                return Center(child: CircularProgressIndicator());
-              } else {
-                if (snapshot.hasData) {
-                  return HomeContainer(
-                    onData: _gcd,
-                    deepLinkData: _deepLinkData,
-                    logEvent: logEvent,
-                  );
-                } else {
-                  return Center(child: Text("Error initializing sdk"));
-                }
-              }
-            }));
-  }
+          ],
+        ),
+      ),
+      body: FutureBuilder<dynamic>(
+        future: appsFlyerService.initializer,
+        builder: (BuildContext context, AsyncSnapshot snapshot) {
+          switch (snapshot.connectionState) {
+            case ConnectionState.none:
+            case ConnectionState.waiting:
+            case ConnectionState.active:
+              return Center(child: CircularProgressIndicator());
+            case ConnectionState.done:
+              return HomeContainer(appsFlyerService: appsFlyerService);
+          }
 
-  Future<bool> logEvent(String eventName, Map<String, dynamic> eventValues) {
-    return _appsflyerSdk.logEvent(eventName, eventValues);
+          return Center(child: Text("Error initializing sdk"));
+        },
+      ),
+    );
   }
 }

--- a/example/lib/utils.dart
+++ b/example/lib/utils.dart
@@ -1,8 +1,29 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
+
 class Utils {
   static String formatJson(jsonObj) {
     final encoder = new JsonEncoder.withIndent('  ');
     return encoder.convert(jsonObj);
+  }
+
+  static String prettyPrintDiagnosticable(Diagnosticable diagnosticable) {
+    return '$diagnosticable'
+        // newline after opening pairs
+        .splitMapJoin(
+          RegExp(r'[\(\{,]'),
+          onMatch: (match) => '${match[0]}\n',
+        )
+        // newline before closing pairs
+        .splitMapJoin(
+          RegExp(r'[\)\}]'),
+          onMatch: (match) => '\n${match[0]}',
+        )
+        // left pad key/value lines
+        .splitMapJoin(
+          RegExp(r'.*?:'),
+          onMatch: (match) => '  ${match[0]}',
+        );
   }
 }

--- a/lib/appsflyer_sdk.dart
+++ b/lib/appsflyer_sdk.dart
@@ -1,14 +1,7 @@
-library appsflyer_sdk;
+// part of is discouraged: https://dart.dev/guides/libraries/create-library-packages#organizing-a-library-package
 
-import 'dart:io';
-import 'package:appsflyer_sdk/src/callbacks.dart';
-import 'package:flutter/services.dart';
-import 'dart:async';
-import 'dart:convert';
-import 'dart:core';
-import 'package:flutter/material.dart';
-
-part 'src/appsflyer_sdk.dart';
-part 'src/appsflyer_constants.dart';
-part 'src/appsflyer_options.dart';
-part 'src/appsflyer_invite_link_params.dart';
+export 'src/appsflyer_constants.dart';
+export 'src/appsflyer_invite_link_params.dart';
+export 'src/appsflyer_options.dart';
+export 'src/appsflyer_response.dart';
+export 'src/appsflyer_sdk.dart';

--- a/lib/src/appsflyer_constants.dart
+++ b/lib/src/appsflyer_constants.dart
@@ -1,5 +1,3 @@
-part of appsflyer_sdk;
-
 enum EmailCryptType {
   EmailCryptTypeNone,
   EmailCryptTypeSHA1,

--- a/lib/src/appsflyer_invite_link_params.dart
+++ b/lib/src/appsflyer_invite_link_params.dart
@@ -16,4 +16,16 @@ class AppsFlyerInviteLinkParams {
     this.customerID,
     this.referreImageUrl,
   });
+
+  Map<String, String?> toJson() {
+    return {
+      'referrerImageUrl': referreImageUrl,
+      'customerID': customerID,
+      'brandDomain': brandDomain,
+      'baseDeeplink': baseDeepLink,
+      'referrerName': referrerName,
+      'channel': channel,
+      'campaign': campaign,
+    };
+  }
 }

--- a/lib/src/appsflyer_invite_link_params.dart
+++ b/lib/src/appsflyer_invite_link_params.dart
@@ -1,5 +1,3 @@
-part of appsflyer_sdk;
-
 class AppsFlyerInviteLinkParams {
   final String? channel;
   final String? campaign;

--- a/lib/src/appsflyer_invite_link_params.dart
+++ b/lib/src/appsflyer_invite_link_params.dart
@@ -2,7 +2,7 @@ class AppsFlyerInviteLinkParams {
   final String? channel;
   final String? campaign;
   final String? referrerName;
-  final String? referreImageUrl;
+  final String? referrerImageUrl;
   final String? customerID;
   final String? baseDeepLink;
   final String? brandDomain;
@@ -14,12 +14,12 @@ class AppsFlyerInviteLinkParams {
     this.baseDeepLink,
     this.brandDomain,
     this.customerID,
-    this.referreImageUrl,
+    this.referrerImageUrl,
   });
 
   Map<String, String?> toJson() {
     return {
-      'referrerImageUrl': referreImageUrl,
+      'referrerImageUrl': referrerImageUrl,
       'customerID': customerID,
       'brandDomain': brandDomain,
       'baseDeeplink': baseDeepLink,

--- a/lib/src/appsflyer_options.dart
+++ b/lib/src/appsflyer_options.dart
@@ -1,19 +1,35 @@
+import '../appsflyer_sdk.dart';
+
 class AppsFlyerOptions {
   final String afDevKey;
-  final bool showDebug;
-  final String appId;
   final double? timeToWaitForATTUserAuthorization;
   final String? appInviteOneLink;
   final bool? disableAdvertisingIdentifier;
   final bool? disableCollectASA;
+  final bool showDebug;
+  final String appId;
 
   AppsFlyerOptions({
     required this.afDevKey,
-    this.showDebug = false,
-    this.appId = "",
     this.timeToWaitForATTUserAuthorization,
     this.appInviteOneLink,
     this.disableAdvertisingIdentifier,
     this.disableCollectASA,
+    this.showDebug = false,
+    this.appId = "",
   });
+
+  Map<String, dynamic> toJson() {
+    return {
+      AppsflyerConstants.afDevKey: afDevKey,
+      AppsflyerConstants.afTimeToWaitForAttUserAuthorization:
+          timeToWaitForATTUserAuthorization,
+      AppsflyerConstants.afInviteOneLink: appInviteOneLink,
+      AppsflyerConstants.disableAdvertisingIdentifier:
+          disableAdvertisingIdentifier,
+      AppsflyerConstants.disableCollectASA: disableCollectASA,
+      AppsflyerConstants.afIsDebug: showDebug,
+      AppsflyerConstants.afAppId: appId,
+    };
+  }
 }

--- a/lib/src/appsflyer_options.dart
+++ b/lib/src/appsflyer_options.dart
@@ -1,5 +1,3 @@
-part of appsflyer_sdk;
-
 class AppsFlyerOptions {
   final String afDevKey;
   final bool showDebug;

--- a/lib/src/appsflyer_response.dart
+++ b/lib/src/appsflyer_response.dart
@@ -1,13 +1,13 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 
-typedef ObjectConverter<T> = T Function(Map<String, dynamic>? data);
-typedef DataResponse = void Function(Map<String, dynamic>? data);
+typedef ObjectConverter<T> = T Function(Map<String, dynamic>? json);
+typedef DataResponse = void Function(Map<String, dynamic>? json);
 typedef UnknownResponse = void Function(dynamic data);
 
 /// Either a [AppsFlyerData] or [AppsFlyerUnknown] object
 ///
-/// Use the [then] or [when] methods on this class to handle responses
+/// Use the [map] or [when] methods on this class to handle responses
 abstract class AppsFlyerResponse<T> extends Equatable with Diagnosticable {
   final String status;
   final T payload;
@@ -27,9 +27,13 @@ abstract class AppsFlyerResponse<T> extends Equatable with Diagnosticable {
   /// Convert the successful response into the object of your choosing
   ///
   /// Note: throws an error when the object cannot be converted
-  T? then<T>(ObjectConverter<T> fromJson) {
-    if (runtimeType is AppsFlyerData) {
-      return fromJson(payload as Map<String, dynamic>?);
+  T? map<T>(ObjectConverter<T> builder) {
+    final hasData = this is AppsFlyerData;
+
+    if (hasData) {
+      final json = payload as Map<String, dynamic>?;
+
+      return builder(json);
     }
 
     return null;
@@ -38,15 +42,16 @@ abstract class AppsFlyerResponse<T> extends Equatable with Diagnosticable {
   /// Provides a convenient way of handling both known and unknown values
   /// returned from the platform.
   ///
-  /// See also: [then] to handle only known responses
+  /// See also: [map] to handle only known responses
   void when({
     required DataResponse data,
     required UnknownResponse other,
   }) {
     switch (runtimeType) {
       case AppsFlyerData:
-        assert(payload is Map<String, dynamic>?);
-        data(payload as Map<String, dynamic>?);
+        final json = payload as Map<String, dynamic>?;
+
+        data(json);
         break;
       case AppsFlyerUnknown:
         other(payload);
@@ -65,4 +70,81 @@ class AppsFlyerData extends AppsFlyerResponse<Map<String, dynamic>?> {
 class AppsFlyerUnknown extends AppsFlyerResponse<dynamic> {
   const AppsFlyerUnknown(dynamic payload)
       : super(status: 'unknown', payload: payload);
+}
+
+class OneLinkBase with Diagnosticable {
+  final String campaign;
+  final String mediaSource;
+  final bool isDeferred;
+
+  OneLinkBase._({
+    required this.campaign,
+    required this.mediaSource,
+    required this.isDeferred,
+  });
+
+  /// Convert JSON data to a [OneLinkBase]
+  static OneLinkBase fromJson(Map<String, dynamic> json) {
+    final campaign = json['campaign'];
+    final mediaSource = json['media_source'];
+    final isDeferred = json['is_deferred'];
+
+    return OneLinkBase._(
+      campaign: campaign,
+      mediaSource: mediaSource,
+      isDeferred: isDeferred,
+    );
+  }
+
+  /// Prints the information below when [toString] is called
+  ///
+  /// Extremely helpful for debugging
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsNode.message('campaign: $campaign'));
+    properties.add(DiagnosticsNode.message('mediaSource: $mediaSource'));
+    properties.add(DiagnosticsNode.message('isDeferred: $isDeferred'));
+  }
+}
+
+class AppInstallResponse with Diagnosticable {
+  final DateTime installTime;
+  final String status;
+  final String message;
+  final bool isFirstLaunch;
+
+  AppInstallResponse._({
+    required this.installTime,
+    required this.status,
+    required this.message,
+    required this.isFirstLaunch,
+  });
+
+  static AppInstallResponse fromJson(Map<String, dynamic> json) {
+    final installTime = json['install_time'];
+    final status = json['af_status'];
+    final message = json['af_message'];
+    final isFirstLaunch = json['is_first_launch'];
+
+    return AppInstallResponse._(
+      installTime: DateTime.parse(installTime),
+      status: status,
+      message: message,
+      isFirstLaunch: isFirstLaunch,
+    );
+  }
+
+  /// Prints the information below when [toString] is called
+  ///
+  /// Extremely helpful for debugging
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsNode.message(
+        'InstallTime: ${installTime.toIso8601String()}'));
+    properties.add(DiagnosticsNode.message('status: $status'));
+    properties.add(DiagnosticsNode.message('message: $message'));
+    properties.add(DiagnosticsNode.message('isFirstLaunch: $isFirstLaunch'));
+  }
 }

--- a/lib/src/appsflyer_response.dart
+++ b/lib/src/appsflyer_response.dart
@@ -60,6 +60,29 @@ abstract class AppsFlyerResponse<T> extends Equatable with Diagnosticable {
   }
 }
 
+/// A successful response from the native Platform
+///
+///
+/// Use [map] to convert the [payload] returned by the Platform into an object
+/// of your choosing
+///
+/// ## Example
+///
+/// ```dart
+/// ..onDeepLinking((AppsFlyerResponse response) {
+///     final deepLink = response.map((json) {
+///         if(json != null) return DeepLinkResponse.fromJson(json);
+///
+///         return null;
+///     });
+///
+///     print(deepLink?.toString() ?? 'Deep Link Does Not Exist');
+/// });
+/// ```
+///
+/// Platform Responses: [PlatformResponse.onAppOpenAttribution],
+/// [PlatformResponse.onDeepLinking], [PlatformResponse.validatePurchase],
+/// [PlatformResponse.generateInviteLinkSuccess]
 class AppsFlyerData extends AppsFlyerResponse<Map<String, dynamic>?> {
   const AppsFlyerData({
     required String status,
@@ -67,11 +90,102 @@ class AppsFlyerData extends AppsFlyerResponse<Map<String, dynamic>?> {
   }) : super(status: status, payload: payload);
 }
 
+/// Unknown responses from the Platform
+///
+/// Unstructured data returned from to the AppsFlyer SDK by the Platform
 class AppsFlyerUnknown extends AppsFlyerResponse<dynamic> {
   const AppsFlyerUnknown(dynamic payload)
       : super(status: 'unknown', payload: payload);
 }
 
+/// Base information returned from Deep Linking callbacks
+///
+/// ## Examples
+///
+/// ### Example 1: Standalone
+/// ```dart
+/// import 'appsflyer_sdk/appsflyer_sdk.dart';
+///
+/// ...
+///
+/// ..onDeepLinking((AppsFlyerResponse response) {
+///     final deepLink = response.map((json) {
+///         if(json != null) return OneLinkBase.fromJson(json);
+///
+///         return null;
+///     });
+///
+///     print(deepLink?.toString() ?? 'Deep Link Does Not Exist');
+/// });
+/// ```
+///
+/// ### Example 2: Custom Properties (Composition)
+///
+/// #### Setup
+/// ```dart
+/// class DeepLinkResponse with Diagnosticable {
+///  final OneLinkBase base;
+///  // Add your custom attributes below here
+///  final String product; // example attribute
+///  final String branch; // example attribute
+///
+///  DeepLinkResponse._({
+///    @required this.base,
+///    @required this.product,
+///    @required this.branch,
+///  });
+///
+///  /// Convert JSON data to a [DeepLinkResponse]
+///  static DeepLinkResponse fromJson(Map<String, dynamic> json) {
+///    try {
+///      final base = OneLinkBase.fromJson(json);
+///      // Your custom attributes
+///      final product = json['product'];
+///      final branch = json['branch'];
+///
+///      final result = DeepLinkResponse._(
+///        base: base,
+///        product: product,
+///        branch: branch,
+///      );
+///
+///      debugPrint('$DeepLinkResponse created! $result');
+///
+///      return result;
+///    } catch (e) {
+///      debugPrint('$DeepLinkResponse creation failed: $e');
+///    }
+///
+///    return null;
+///  }
+///
+///  /// Prints the information below when [toString] is called
+///  ///
+///  /// Extremely helpful for debugging
+///  @override
+///  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+///    super.debugFillProperties(properties);
+///    properties.add(DiagnosticsNode.message('$base'));
+///    // Your custom attributes
+///    properties.add(DiagnosticsNode.message('product: $product'));
+///    properties.add(DiagnosticsNode.message('branch: $branch'));
+///  }
+///}
+/// ```
+///
+/// #### Usage
+///
+/// ```dart
+/// ..onDeepLinking((AppsFlyerResponse response) {
+///     final deepLink = response.map((json) {
+///         if(json != null) return DeepLinkResponse.fromJson(json);
+///
+///         return null;
+///     });
+///
+///     print(deepLink?.toString() ?? 'Deep Link Does Not Exist');
+/// });
+/// ```
 class OneLinkBase with Diagnosticable {
   final String campaign;
   final String mediaSource;
@@ -108,6 +222,9 @@ class OneLinkBase with Diagnosticable {
   }
 }
 
+/// Information when the app is installed
+///
+/// Platform Response: [PlatformResponse.onInstallConversionData]
 class AppInstallResponse with Diagnosticable {
   final DateTime installTime;
   final String status;

--- a/lib/src/appsflyer_response.dart
+++ b/lib/src/appsflyer_response.dart
@@ -1,0 +1,68 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/foundation.dart';
+
+typedef ObjectConverter<T> = T Function(Map<String, dynamic>? data);
+typedef DataResponse = void Function(Map<String, dynamic>? data);
+typedef UnknownResponse = void Function(dynamic data);
+
+/// Either a [AppsFlyerData] or [AppsFlyerUnknown] object
+///
+/// Use the [then] or [when] methods on this class to handle responses
+abstract class AppsFlyerResponse<T> extends Equatable with Diagnosticable {
+  final String status;
+  final T payload;
+
+  const AppsFlyerResponse({required this.status, required this.payload});
+
+  @override
+  List<Object?> get props => [status, payload];
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsNode.message(status));
+    properties.add(DiagnosticsNode.message('$payload'));
+  }
+
+  /// Convert the successful response into the object of your choosing
+  ///
+  /// Note: throws an error when the object cannot be converted
+  T? then<T>(ObjectConverter<T> fromJson) {
+    if (runtimeType is AppsFlyerData) {
+      return fromJson(payload as Map<String, dynamic>?);
+    }
+
+    return null;
+  }
+
+  /// Provides a convenient way of handling both known and unknown values
+  /// returned from the platform.
+  ///
+  /// See also: [then] to handle only known responses
+  void when({
+    required DataResponse data,
+    required UnknownResponse other,
+  }) {
+    switch (runtimeType) {
+      case AppsFlyerData:
+        assert(payload is Map<String, dynamic>?);
+        data(payload as Map<String, dynamic>?);
+        break;
+      case AppsFlyerUnknown:
+        other(payload);
+        break;
+    }
+  }
+}
+
+class AppsFlyerData extends AppsFlyerResponse<Map<String, dynamic>?> {
+  const AppsFlyerData({
+    required String status,
+    required Map<String, dynamic>? payload,
+  }) : super(status: status, payload: payload);
+}
+
+class AppsFlyerUnknown extends AppsFlyerResponse<dynamic> {
+  const AppsFlyerUnknown(dynamic payload)
+      : super(status: 'unknown', payload: payload);
+}

--- a/lib/src/appsflyer_sdk.dart
+++ b/lib/src/appsflyer_sdk.dart
@@ -1,6 +1,18 @@
-part of appsflyer_sdk;
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import 'appsflyer_constants.dart';
+import 'appsflyer_invite_link_params.dart';
+import 'appsflyer_options.dart';
+import 'callbacks.dart';
+import 'platform_enums.dart';
 
 class AppsflyerSdk {
+  static final Callbacks callbacks = Callbacks();
   // ignore: close_sinks
   StreamController? _afGCDStreamController;
   // ignore: close_sinks
@@ -90,7 +102,7 @@ class AppsflyerSdk {
       validatedOptions[AppsflyerConstants.AF_GCD] = false;
     }
 
-    if (_afUDLStreamController != null ) {
+    if (_afUDLStreamController != null) {
       validatedOptions[AppsflyerConstants.AF_UDL] = true;
     } else {
       validatedOptions[AppsflyerConstants.AF_UDL] = false;
@@ -157,7 +169,7 @@ class AppsflyerSdk {
       afOptions[AppsflyerConstants.AF_GCD] = false;
     }
 
-    if (_afUDLStreamController != null ) {
+    if (_afUDLStreamController != null) {
       afOptions[AppsflyerConstants.AF_UDL] = true;
     } else {
       afOptions[AppsflyerConstants.AF_UDL] = false;
@@ -176,7 +188,8 @@ class AppsflyerSdk {
   }
 
   Stream<Map>? get conversionDataStream {
-    return _afGCDStreamController?.stream.asBroadcastStream() as Stream<Map<dynamic, dynamic>>?;
+    return _afGCDStreamController?.stream.asBroadcastStream()
+        as Stream<Map<dynamic, dynamic>>?;
   }
 
   // Accessing AppsFlyer attribution, referred from deep linking
@@ -188,9 +201,9 @@ class AppsflyerSdk {
     }
   }
 
-
   Stream<Map>? get appOpenAttributionStream {
-    return _afOpenAttributionStreamController?.stream.asBroadcastStream() as Stream<Map<dynamic, dynamic>>?;
+    return _afOpenAttributionStreamController?.stream.asBroadcastStream()
+        as Stream<Map<dynamic, dynamic>>?;
   }
 
   // Unified deeplink: Accessing AppsFlyer deeplink attributes
@@ -204,12 +217,13 @@ class AppsflyerSdk {
   }
 
   Stream<Map>? get onDeepLinkingStream {
-    return _afUDLStreamController?.stream.asBroadcastStream() as Stream<Map<dynamic, dynamic>>?;
+    return _afUDLStreamController?.stream.asBroadcastStream()
+        as Stream<Map<dynamic, dynamic>>?;
   }
 
   ///Returns `Stream`. Accessing AppsFlyer purchase validation data
-   // ignore: unused_element
-   Stream<dynamic> _registerValidatePurchaseStream() {
+  // ignore: unused_element
+  Stream<dynamic> _registerValidatePurchaseStream() {
     if (_afValidtaPurchaseController == null) {
       _afValidtaPurchaseController = StreamController(onCancel: () {
         _afValidtaPurchaseController!.close();
@@ -226,7 +240,6 @@ class AppsflyerSdk {
       bool registerOnAppOpenAttributionCallback = false,
       bool registerOnDeepLinkingCallback = false}) async {
     return Future.delayed(Duration(seconds: 0)).then((_) {
-      
       if (registerConversionDataCallback) _registerConversionDataCallback();
       if (registerOnAppOpenAttributionCallback)
         _registerOnAppOpenAttributionCallback();
@@ -238,7 +251,7 @@ class AppsflyerSdk {
 
       if (registerOnDeepLinkingCallback) {
         _registerUDLCallback();
-      }      
+      }
 
       Map<String, dynamic>? validatedOptions;
       if (mapOptions != null) {
@@ -247,12 +260,14 @@ class AppsflyerSdk {
         validatedOptions = _validateAFOptions(afOptions!);
       }
 
-      return _methodChannel.invokeMethod("initSdk", validatedOptions);
+      final initSdk = PlatformMethod.initSdk.asString();
+      return _methodChannel.invokeMethod(initSdk, validatedOptions);
     });
   }
 
   Future<String?> getSDKVersion() async {
-    return _methodChannel.invokeMethod("getSDKVersion");
+    final getSDKVersion = PlatformMethod.getSDKVersion.asString();
+    return _methodChannel.invokeMethod(getSDKVersion);
   }
 
   ///These in-app events help you to log how loyal users discover your app, and attribute them to specific
@@ -276,66 +291,79 @@ class AppsflyerSdk {
   /// If the app does NOT contain Google Play Services, device IMEI is collected by the SDK.
   /// However, apps with Google play services should avoid IMEI collection as this is in violation of the Google Play policy.
   void setCollectIMEI(bool isCollect) {
-    _methodChannel.invokeMethod("setCollectIMEI", {'isCollect': isCollect});
+    final setCollectIMEI = PlatformMethod.setCollectIMEI.asString();
+    _methodChannel.invokeMethod(setCollectIMEI, {'isCollect': isCollect});
   }
 
   /// Opt-out of collection of Android ID.
   /// If the app does NOT contain Google Play Services, Android ID is collected by the SDK.
   /// However, apps with Google play services should avoid Android ID collection as this is in violation of the Google Play policy.
   void setCollectAndroidId(bool isCollect) {
-    _methodChannel
-        .invokeMethod("setCollectAndroidId", {'isCollect': isCollect});
+    final setCollectAndroidId = PlatformMethod.setCollectAndroidId.asString();
+    _methodChannel.invokeMethod(setCollectAndroidId, {'isCollect': isCollect});
   }
 
   Future<String?> getHostName() async {
-    return await _methodChannel.invokeMethod("getHostName");
+    final getHostName = PlatformMethod.getHostName.asString();
+    return await _methodChannel.invokeMethod(getHostName);
   }
 
   Future<String?> getHostPrefix() async {
-    return await _methodChannel.invokeMethod("getHostPrefix");
+    final getHostPrefix = PlatformMethod.getHostPrefix.asString();
+    return await _methodChannel.invokeMethod(getHostPrefix);
   }
 
   void setAndroidIdData(String androidId) {
-    _methodChannel.invokeMethod("setAndroidIdData", {'androidId': androidId});
+    final setAndroidIdData = PlatformMethod.setAndroidIdData.asString();
+    _methodChannel.invokeMethod(setAndroidIdData, {'androidId': androidId});
   }
 
   void setMinTimeBetweenSessions(int seconds) {
     assert(seconds >= 0, "the minimum timeout must be a positive number");
+    final setMinTimeBetweenSessions =
+        PlatformMethod.setMinTimeBetweenSessions.asString();
     _methodChannel
-        .invokeMethod("setMinTimeBetweenSessions", {'seconds': seconds});
+        .invokeMethod(setMinTimeBetweenSessions, {'seconds': seconds});
   }
 
   void setImeiData(String imei) {
-    _methodChannel.invokeMethod("setImeiData", {'imei': imei});
+    final setImeiData = PlatformMethod.setImeiData.asString();
+    _methodChannel.invokeMethod(setImeiData, {'imei': imei});
   }
 
   /// Setting user local currency code for in-app purchases.
   /// The currency code should be a 3 character ISO 4217 code. (default is USD).
   /// You can set the currency code for all events by calling the following method.
   void setCurrencyCode(String currencyCode) {
+    final setCurrencyCode = PlatformMethod.setCurrencyCode.asString();
     _methodChannel
-        .invokeMethod("setCurrencyCode", {'currencyCode': currencyCode});
+        .invokeMethod(setCurrencyCode, {'currencyCode': currencyCode});
   }
 
   /// Setting your own customer ID enables you to cross-reference your own unique ID with AppsFlyer’s unique ID and the other devices’ IDs.
   /// This ID is available in AppsFlyer CSV reports along with Postback APIs for cross-referencing with your internal IDs.
   void setCustomerUserId(String id) {
-    _methodChannel.invokeMethod("setCustomerUserId", {'id': id});
+    final setCustomerUserId = PlatformMethod.setCustomerUserId.asString();
+    _methodChannel.invokeMethod(setCustomerUserId, {'id': id});
   }
 
   void setIsUpdate(bool isUpdate) {
-    _methodChannel.invokeMethod("setIsUpdate", {'isUpdate': isUpdate});
+    final setIsUpdate = PlatformMethod.setIsUpdate.asString();
+    _methodChannel.invokeMethod(setIsUpdate, {'isUpdate': isUpdate});
   }
 
   /// Once this API is invoked, our SDK no longer communicates with our servers and stops functioning.
   /// In some extreme cases you might want to shut down all SDK activity due to legal and privacy compliance.
   /// This can be achieved with the stop API.
   void stop(bool isStopped) {
-    _methodChannel.invokeMethod("stop", {'isStopped': isStopped});
+    final stop = PlatformMethod.stop.asString();
+    _methodChannel.invokeMethod(stop, {'isStopped': isStopped});
   }
 
   void enableLocationCollection(bool flag) {
-    _methodChannel.invokeMethod("enableLocationCollection", {'flag': flag});
+    final enableLocationCollection =
+        PlatformMethod.enableLocationCollection.asString();
+    _methodChannel.invokeMethod(enableLocationCollection, {'flag': flag});
   }
 
   ///Please use updateServerUninstallToken instead
@@ -346,46 +374,55 @@ class AppsflyerSdk {
 
   ///Manually pass the Firebase / GCM Device Token for Uninstall measurement.
   void updateServerUninstallToken(String token) {
-    _methodChannel.invokeMethod("updateServerUninstallToken", {'token': token});
+    final updateServerUninstallToken =
+        PlatformMethod.updateServerUninstallToken.asString();
+    _methodChannel.invokeMethod(updateServerUninstallToken, {'token': token});
   }
 
   ///Set the user emails and encrypt them.
   void setUserEmails(List<String> emails, [EmailCryptType? cryptType]) {
     if (cryptType != null) {
       int cryptTypeInt = EmailCryptType.values.indexOf(cryptType);
-      _methodChannel.invokeMethod("setUserEmailsWithCryptType",
+      final setUserEmailsWithCryptType =
+          PlatformMethod.setUserEmailsWithCryptType.asString();
+      _methodChannel.invokeMethod(setUserEmailsWithCryptType,
           {'emails': emails, 'cryptType': cryptTypeInt});
     } else {
-      _methodChannel.invokeMethod("setUserEmails", {'emails': emails});
+      final setUserEmails = PlatformMethod.setUserEmails.asString();
+      _methodChannel.invokeMethod(setUserEmails, {'emails': emails});
     }
   }
 
   ///Get AppsFlyer's unique device ID is created for every new install of an app.
   Future<String?> getAppsFlyerUID() async {
-    return await _methodChannel.invokeMethod("getAppsFlyerUID");
+    final getAppsFlyerUID = PlatformMethod.getAppsFlyerUID.asString();
+    return await _methodChannel.invokeMethod(getAppsFlyerUID);
   }
 
   ///Set to true if you want to delay sdk init until CUID is set
   void waitForCustomerUserId(bool wait) {
-    _methodChannel.invokeMethod("waitForCustomerUserId", {'wait': wait});
+    final waitForCustomerUserId =
+        PlatformMethod.waitForCustomerUserId.asString();
+    _methodChannel.invokeMethod(waitForCustomerUserId, {'wait': wait});
   }
 
-  Future<dynamic> validateAndLogInAppAndroidPurchase (
+  Future<dynamic> validateAndLogInAppAndroidPurchase(
       String publicKey,
       String signature,
       String purchaseData,
       String price,
       String currency,
       Map<String, String>? additionalParameters) {
-
-      return _methodChannel.invokeMethod("validateAndLogInAppAndroidPurchase", {
-        'publicKey': publicKey,
-        'signature': signature,
-        'purchaseData': purchaseData,
-        'price': price,
-        'currency': currency,
-        'additionalParameters': additionalParameters
-      });
+    final validateAndLogInAppAndroidPurchase =
+        PlatformMethod.validateAndLogInAppAndroidPurchase.asString();
+    return _methodChannel.invokeMethod(validateAndLogInAppAndroidPurchase, {
+      'publicKey': publicKey,
+      'signature': signature,
+      'purchaseData': purchaseData,
+      'price': price,
+      'currency': currency,
+      'additionalParameters': additionalParameters
+    });
   }
 
   ///Accessing AppsFlyer purchase validation data
@@ -394,35 +431,38 @@ class AppsflyerSdk {
       String price,
       String currency,
       String transactionId,
-      Map<String, String> additionalParameters)async{
-      return await _methodChannel.invokeMethod("validateAndLogInAppIosPurchase", {
-        'productIdentifier': productIdentifier,
-        'price': price,
-        'currency': currency,
-        'transactionId': transactionId,
-        'additionalParameters': additionalParameters
-      });
+      Map<String, String> additionalParameters) async {
+    final validateAndLogInAppIosPurchase =
+        PlatformMethod.validateAndLogInAppIosPurchase.asString();
+    return await _methodChannel.invokeMethod(validateAndLogInAppIosPurchase, {
+      'productIdentifier': productIdentifier,
+      'price': price,
+      'currency': currency,
+      'transactionId': transactionId,
+      'additionalParameters': additionalParameters
+    });
   }
 
   /// set sandbox for iOS purchase validation
   void useReceiptValidationSandbox(bool isSandboxEnabled) {
-    _methodChannel.invokeMethod("useReceiptValidationSandbox", isSandboxEnabled);
+    _methodChannel.invokeMethod(
+        "useReceiptValidationSandbox", isSandboxEnabled);
   }
 
   /// Set additional data to be sent to AppsFlyer.
   void setAdditionalData(Map<String, dynamic>? customData) {
-    _methodChannel
-        .invokeMethod("setAdditionalData", {'customData': customData});
+    final setAdditionalData = PlatformMethod.setAdditionalData.asString();
+    _methodChannel.invokeMethod(setAdditionalData, {'customData': customData});
   }
 
   void _registerUDLListener() {
-    _eventChannel.receiveBroadcastStream().listen((data) { 
+    _eventChannel.receiveBroadcastStream().listen((data) {
       var decodedJSON = jsonDecode(data);
       String? type = decodedJSON['type'];
-      if(type == AppsflyerConstants.AF_ON_DEEP_LINK){
+      if (type == AppsflyerConstants.AF_ON_DEEP_LINK) {
         if (_afUDLStreamController != null &&
-              !_afUDLStreamController!.isClosed) {
-            _afUDLStreamController!.sink.add(decodedJSON);
+            !_afUDLStreamController!.isClosed) {
+          _afUDLStreamController!.sink.add(decodedJSON);
         } else {
           if ((afOptions != null && afOptions!.showDebug) ||
               (mapOptions != null &&
@@ -481,25 +521,35 @@ class AppsflyerSdk {
   ///The sharing filter blocks the sharing of S2S events via postbacks/API with integrated partners and other third-party integrations.
   ///Use the filter to fulfill regulatory requirements like GDPR and CCPA, to comply with user opt-out mechanisms, and for other business logic reasons.
   void setSharingFilter(List<String> filters) {
-    _methodChannel.invokeMethod("setSharingFilter", filters);
+    final setSharingFilter = PlatformMethod.setSharingFilter.asString();
+    _methodChannel.invokeMethod(setSharingFilter, filters);
   }
 
   void setSharingFilterForAllPartners() {
-    _methodChannel.invokeMethod("setSharingFilterForAllPartners");
+    final setSharingFilterForAllPartners =
+        PlatformMethod.setSharingFilterForAllPartners.asString();
+    _methodChannel.invokeMethod(setSharingFilterForAllPartners);
   }
 
   void generateInviteLink(
     AppsFlyerInviteLinkParams? parameters,
-    Function success,
-    Function error,
+    ResponseCallback success,
+    ResponseCallback error,
   ) {
     Map<String, String?>? paramsMap;
     if (parameters != null) {
       paramsMap = _translateInviteLinkParamsToMap(parameters);
     }
-    startListening(success as void Function(dynamic), "generateInviteLinkSuccess");
-    startListening(error as void Function(dynamic), "generateInviteLinkFailure");
-    _methodChannel.invokeMethod("generateInviteLink", paramsMap);
+    callbacks.startListening(
+      responseCallback: success,
+      platformResponse: PlatformResponse.generateInviteLinkSuccess,
+    );
+    callbacks.startListening(
+      responseCallback: error,
+      platformResponse: PlatformResponse.generateInviteLinkFailure,
+    );
+    final generateInviteLink = PlatformMethod.generateInviteLink.asString();
+    _methodChannel.invokeMethod(generateInviteLink, paramsMap);
   }
 
   Map<String, String?> _translateInviteLinkParamsToMap(
@@ -519,9 +569,13 @@ class AppsflyerSdk {
   ///Set the OneLink ID that should be used for User-Invite-API.
   ///The link that is generated for the user invite will use this OneLink ID as the base link ID
   Future<void> setAppInviteOneLinkID(
-      String oneLinkID, Function callback) async {
-    startListening(callback as void Function(dynamic), "setAppInviteOneLinkIDCallback");
-    await _methodChannel.invokeMethod("setAppInviteOneLinkID", {
+      String oneLinkID, ResponseCallback callback) async {
+    callbacks.startListening(
+        responseCallback: callback,
+        platformResponse: PlatformResponse.setAppInviteOneLinkIDCallback);
+    final setAppInviteOneLinkID =
+        PlatformMethod.setAppInviteOneLinkID.asString();
+    await _methodChannel.invokeMethod(setAppInviteOneLinkID, {
       'oneLinkID': oneLinkID,
     });
   }
@@ -529,14 +583,18 @@ class AppsflyerSdk {
   ///To attribute an impression use the following API call.
   ///Make sure to use the promoted App ID as it appears within the AppsFlyer dashboard.
   void logCrossPromotionImpression(String appId, String campaign, Map? data) {
-    _methodChannel.invokeMethod("logCrossPromotionImpression",
+    final logCrossPromotionImpression =
+        PlatformMethod.logCrossPromotionImpression.asString();
+    _methodChannel.invokeMethod(logCrossPromotionImpression,
         {'appId': appId, 'campaign': campaign, 'data': data});
   }
 
   ///Use the following API to attribute the click and launch the app store's app page.
   void logCrossPromotionAndOpenStore(
       String appId, String campaign, Map? params) {
-    _methodChannel.invokeMethod("logCrossPromotionAndOpenStore", {
+    final logCrossPromotionAndOpenStore =
+        PlatformMethod.logCrossPromotionAndOpenStore.asString();
+    _methodChannel.invokeMethod(logCrossPromotionAndOpenStore, {
       'appId': appId,
       'campaign': campaign,
       'params': params,
@@ -544,34 +602,53 @@ class AppsflyerSdk {
   }
 
   void setOneLinkCustomDomain(List<String> brandDomains) {
-    _methodChannel.invokeMethod("setOneLinkCustomDomain", brandDomains);
+    final setOneLinkCustomDomain =
+        PlatformMethod.setOneLinkCustomDomain.asString();
+    _methodChannel.invokeMethod(setOneLinkCustomDomain, brandDomains);
   }
 
   void setPushNotification(bool isEnabled) {
-    _methodChannel.invokeMethod("setPushNotification", isEnabled);
+    final setPushNotification = PlatformMethod.setPushNotification.asString();
+    _methodChannel.invokeMethod(setPushNotification, isEnabled);
   }
 
   void enableFacebookDeferredApplinks(bool isEnabled) {
-    _methodChannel.invokeMethod("enableFacebookDeferredApplinks", { 'isFacebookDeferredApplinksEnabled': isEnabled });
+    final enableFacebookDeferredApplinks =
+        PlatformMethod.enableFacebookDeferredApplinks.asString();
+    _methodChannel.invokeMethod(enableFacebookDeferredApplinks,
+        {'isFacebookDeferredApplinksEnabled': isEnabled});
   }
 
- void disableSKAdNetwork(bool isEnabled) {
-    _methodChannel.invokeMethod("disableSKAdNetwork", isEnabled);
+  void disableSKAdNetwork(bool isEnabled) {
+    final disableSKAdNetwork = PlatformMethod.disableSKAdNetwork.asString();
+    _methodChannel.invokeMethod(disableSKAdNetwork, isEnabled);
   }
 
-  void onInstallConversionData(Function callback) async {
-    startListening(callback as void Function(dynamic), "onInstallConversionData");
+  void onInstallConversionData(ResponseCallback callback) async {
+    callbacks.startListening(
+      responseCallback: callback,
+      platformResponse: PlatformResponse.onInstallConversionData,
+    );
   }
 
-  void onAppOpenAttribution(Function callback) async {
-    startListening(callback as void Function(dynamic), "onAppOpenAttribution");
+  void onAppOpenAttribution(ResponseCallback callback) async {
+    callbacks.startListening(
+      responseCallback: callback,
+      platformResponse: PlatformResponse.onAppOpenAttribution,
+    );
   }
 
-  void onDeepLinking(Function callback) async {
-    startListening(callback as void Function(dynamic), "onDeepLinking");
+  void onDeepLinking(ResponseCallback callback) async {
+    callbacks.startListening(
+      responseCallback: callback,
+      platformResponse: PlatformResponse.onDeepLinking,
+    );
   }
 
-  void onPurchaseValidation(Function callback) async {
-    startListening(callback as void Function(dynamic), "validatePurchase");
+  void onPurchaseValidation(ResponseCallback callback) async {
+    callbacks.startListening(
+      responseCallback: callback,
+      platformResponse: PlatformResponse.validatePurchase,
+    );
   }
 }

--- a/lib/src/platform_enums.dart
+++ b/lib/src/platform_enums.dart
@@ -56,12 +56,23 @@ extension PlatformResponseExtension on PlatformResponse {
 }
 
 extension MethodCallIdExtension on String {
-  PlatformResponse toEnum() {
+  PlatformResponse toPlatformResponse() {
     // Throw if we don't find an enum to match on
-    return PlatformResponse.values.firstWhere(_matchesEnum(this));
+    return PlatformResponse.values.firstWhere(_matchesPlatform(this));
   }
 
-  bool Function(PlatformResponse) _matchesEnum(String current) {
+  PlatformMethod toPlatformMethod() {
+    // Throw if we don't find an enum to match on
+    return PlatformMethod.values.firstWhere(_matchesMethod(this));
+  }
+
+  bool Function(PlatformResponse) _matchesPlatform(String current) {
+    return (e) {
+      return describeEnum(e) == current;
+    };
+  }
+
+  bool Function(PlatformMethod) _matchesMethod(String current) {
     return (e) {
       return describeEnum(e) == current;
     };

--- a/lib/src/platform_enums.dart
+++ b/lib/src/platform_enums.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/foundation.dart';
+
+enum PlatformResponse {
+  onAppOpenAttribution,
+  onInstallConversionData,
+  onDeepLinking,
+  validatePurchase,
+  generateInviteLinkSuccess,
+
+  // Not handled explicitely in Callbacks._methodCallHandler
+  setAppInviteOneLinkIDCallback,
+  generateInviteLinkFailure,
+}
+
+enum PlatformMethod {
+  initSdk,
+  getSDKVersion,
+  setCollectIMEI,
+  setCollectAndroidId,
+  getHostName,
+  getHostPrefix,
+  setAndroidIdData,
+  setMinTimeBetweenSessions,
+  setImeiData,
+  setCurrencyCode,
+  setCustomerUserId,
+  setIsUpdate,
+  stop,
+  enableLocationCollection,
+  updateServerUninstallToken,
+  setUserEmailsWithCryptType,
+  setUserEmails,
+  getAppsFlyerUID,
+  waitForCustomerUserId,
+  validateAndLogInAppAndroidPurchase,
+  validateAndLogInAppIosPurchase,
+  setAdditionalData,
+  setSharingFilter,
+  setSharingFilterForAllPartners,
+  generateInviteLink,
+  setAppInviteOneLinkID,
+  logCrossPromotionImpression,
+  logCrossPromotionAndOpenStore,
+  setOneLinkCustomDomain,
+  setPushNotification,
+  enableFacebookDeferredApplinks,
+  disableSKAdNetwork,
+}
+
+extension PlatformMethodExtension on PlatformMethod {
+  String asString() => describeEnum(this);
+}
+
+extension PlatformResponseExtension on PlatformResponse {
+  String asString() => describeEnum(this);
+}
+
+extension MethodCallIdExtension on String {
+  PlatformResponse toEnum() {
+    // Throw if we don't find an enum to match on
+    return PlatformResponse.values.firstWhere(_matchesEnum(this));
+  }
+
+  bool Function(PlatformResponse) _matchesEnum(String current) {
+    return (e) {
+      return describeEnum(e) == current;
+    };
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,12 +11,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  equatable: 2.0.0 # compare classes by value
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   test: ^1.16.5
-  mockito: 5.0.0
+  mockito: ^5.0.0
 
 flutter:
   plugin:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: appsflyer_sdk
 description: A Flutter plugin for AppsFlyer SDK. Supports iOS and Android.
-version: 6.2.4-nullsafety
+version: 6.2.4+1-nullsafety
 
 homepage: https://github.com/AppsFlyerSDK/flutter_appsflyer_sdk
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: appsflyer_sdk
 description: A Flutter plugin for AppsFlyer SDK. Supports iOS and Android.
-version: 6.2.3+2
+version: 6.2.3+3
 
 homepage: https://github.com/AppsFlyerSDK/flutter_appsflyer_sdk
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: appsflyer_sdk
 description: A Flutter plugin for AppsFlyer SDK. Supports iOS and Android.
-version: 6.2.4+4-nullsafety
+version: 7.0.0-nullsafety
 
 homepage: https://github.com/AppsFlyerSDK/flutter_appsflyer_sdk
 
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  equatable: 2.0.0 # compare classes by value
+  equatable: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: appsflyer_sdk
 description: A Flutter plugin for AppsFlyer SDK. Supports iOS and Android.
-version: 6.2.3+3
+version: 6.2.4
 
 homepage: https://github.com/AppsFlyerSDK/flutter_appsflyer_sdk
 

--- a/test/appsflyer_sdk_test.dart
+++ b/test/appsflyer_sdk_test.dart
@@ -14,8 +14,11 @@ void main() {
 
   setUp(() {
     //test map options way
-    instance = AppsflyerSdk.private(methodChannel, eventChannel,
-        mapOptions: {'afDevKey': 'sdfhj2342cx'});
+    instance = AppsflyerSdk.private(
+      methodChannel,
+      eventChannel,
+      {'afDevKey': 'sdfhj2342cx'},
+    );
 
     methodChannel.setMockMethodCallHandler((methodCall) async {
       final method = methodCall.method;
@@ -47,8 +50,11 @@ void main() {
   group('AppsFlyerSdk', () {
     setUp(() {
       //test map options way
-      instance = AppsflyerSdk.private(methodChannel, eventChannel,
-          mapOptions: {'afDevKey': 'sdfhj2342cx'});
+      instance = AppsflyerSdk.private(
+        methodChannel,
+        eventChannel,
+        {'afDevKey': 'sdfhj2342cx'},
+      );
 
       callbacksChannel.setMockMethodCallHandler((call) async {
         final method = call.method;
@@ -163,7 +169,7 @@ void main() {
     });
 
     test('check generateInviteLink call', () async {
-      instance.generateInviteLink(null, (msg) {}, (err) {});
+      instance.generateInviteLink(null, onSuccess: (msg) {}, onError: (err) {});
 
       expect(selectedMethod, 'generateInviteLink');
     });


### PR DESCRIPTION
## Proposed Changes

### Overall
- Sort imports based on: https://dart.dev/guides/language/effective-dart/style#ordering
- Use `export` rather than `part of`: https://dart.dev/guides/libraries/create-library-packages#organizing-a-library-package
- Convert all implicit `dynamic` typing to explicit types
- Dispose of streams and controllers to prevent memory leaks
- Use `class`es instead of `Map`s

### Native
#### AppsflyerSdkPlugin.java
- fix typo: "Inivte" -> "Invite"

### Source Changes
#### Appsflyer Invite Link Params
- fix typo: "referreImageUrl" -> "referrerImageUrl"
- Add standardized `toJson` method to convert the class to a `Map`

#### Appsflyer Options
- Add standardized 'toJson' method to convert the class to a `Map`

#### New Appsflyer Response
Create generic base class (`AppsFlyerResponse`) with subclasses of type `AppsFlyerData` and `AppsFlyerUnknown`. 

`AppsFlyerData` is provided to the user when we get something back we expect from the method call handler. Inversely, `AppsFlyerUnknown` is returned when we get something back we didn't expect from the method call handler.

Use methods `map` or `when` on either class to handle the result. When `AppsFlyerData` is returned, `map` will pass the `Map` received from the platform to the user's callback so they can transform it into an object of their choosing. `when` allows the user to handle the known (`AppsFlyerData`) and unknown (`AppsFlyerUnknown`) cases as they please.

`AppInstallResponse` maps to the information returned by the platform when the app is installed (`onInstallConversionData`)

`OneLinkBase` maps to the information returned by the platform when handling a deep link ('onAppOpenAttribution` and `onDeepLinking`

#### Appsflyer SDK
- The methods located inside of the `callbacks.dart` file have been contained inside of a class so a new class level property has been added to the `AppsflyerSdk` class
- StreamsControllers are now closed when `dispose` is called (preventing memory leaks)
- Types added throughout, replacing assertions with type safety
- The `factory` functionality was previously split between a type check for `AppsFlyerOptions` or a `Map`. The `Map` functionality has been factored into a second `factory` called `AppsflyerSdk.fromMap` (this was only used in tests from what I can tell). The `private` named constructor now redirects to the `fromMap` `factory` to create the `AppsFlyerOptions` and then calls the regular factory constructor with the typed options.
- There's no need to validate the `AppsFlyerOptions` class now that the code is compile safe, allowing us to remove the `_validateAFOptions` method
- Repurposed `_validateMapOptions` as `_toAFOptions` as a way to validate and create the type safe `AppsFlyerOptions` class
- Type safety conversions

#### Callbacks
- Mostly just making it type safe by changing most all `dynamic` types into compile safe types.
- I added `break`s to the `switch` so I could handle unwrapping the `onDeepLinking` response before returning the `payload` inside the `AppsFlyerData` class. Because of this, I extracted the previous fall-through code into a private method called `_handleKnownResponse`. It's a little more code, but I think it's worth it for usability. 
- Type safety conversions

#### New Platform Enums
- Replaces strings
- The IDE can be used to see where all the value is referenced
- No typos

### Example App
#### New AppsFlyer Service
Create a service to handle communication with the plugin
- Supports initialization and generating an invite link
- Contains an example class (`DeepLinkResponse`) showing how to use composition to build a type safe class to parse custom attributes

#### Main
- Remove debug flag
- Remove `new` keyword (obsolete)

#### Main Page
- Extract logic into service above. Initialize service in `initState`
- Use service `Completer` in `FutureBuilder` to show `HomeContainer`

#### Home Container
- Initialize controllers inside of `initState`
- Dispose of `TextEditingController`s
- Convert `Padding` to `SizedBox` widgets
- Add `LinkGenerator` section
- Add `InfoCard` to top of example to specify, "Attribution and Deep Link data populate after opening a OneLink" 
- Factor out purchase event section into method

#### Utils
- Add `prettyPrintDiagnosticable` function to handle displaying classes that mixin `Diagnosticable` (prints class member information when `toString` is invoked.