### PR TITLE
Fix ConversionListener not unregistered causing leak.

### DIFF
--- a/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
+++ b/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
@@ -796,8 +796,12 @@ public class AppsflyerSdkPlugin implements MethodCallHandler, FlutterPlugin, Act
 
     @Override
     public void onDetachedFromActivity() {
+        AppsFlyerLib.getInstance().unregisterConversionListener();
         activity = null;
         saveCallbacks = true;
+        mContext = null;
+        mApplication = null;
+        mIntent = null;
     }
 
 }


### PR DESCRIPTION
I used Android Studio Profiler and found there is leak when using appsflyer.
After I call unregisterConversionListener() then there would be no leak.
Hope you merge it back in next version.
Thank You.

BTW, I make registerConversionDataCallback to true when initSdk