### PR TITLE
fix: setUserEmailsWithCryptType

### DIFF
--- a/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
+++ b/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
@@ -23,6 +23,7 @@ import com.appsflyer.share.ShareInviteHelper;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -498,7 +499,13 @@ public class AppsflyerSdkPlugin implements MethodCallHandler, FlutterPlugin, Act
     private void setUserEmailsWithCryptType(MethodCall call, Result result) {
         List<String> emails = call.argument("emails");
         int cryptTypeInt = call.argument("cryptType");
-        AppsFlyerProperties.EmailsCryptType cryptType = AppsFlyerProperties.EmailsCryptType.values()[cryptTypeInt];
+        AppsFlyerProperties.EmailsCryptType cryptType = null;
+        if (cryptTypeInt == 0)
+            cryptType= AppsFlyerProperties.EmailsCryptType.NONE;
+        if (cryptTypeInt == 3)
+            cryptType= AppsFlyerProperties.EmailsCryptType.SHA256;
+        if (cryptTypeInt == 1 || cryptTypeInt==2)
+            throw new InvalidParameterException("you can use only NONE or SHA256 for EmailsCryptType on android");
         if (emails != null) {
             AppsFlyerLib.getInstance().setUserEmails(cryptType, emails.toArray(new String[0]));
         }


### PR DESCRIPTION
AppsFlyerProperties.EmailsCryptType have only 2 value
fixed:
PlatformException(error, length=2; index=3, null, java.lang.ArrayIndexOutOfBoundsException: length=2; index=3
	at com.appsflyer.appsflyersdk.AppsflyerSdkPlugin.setUserEmailsWithCryptType(AppsflyerSdkPlugin.java:3)
	at com.appsflyer.appsflyersdk.AppsflyerSdkPlugin.onMethodCall(AppsflyerSdkPlugin.java:23)
	at d.a.d.a.j$a.a(MethodChannel.java:2)
	at io.flutter.embedding.engine.f.b.a(DartMessenger.java:15)
	at io.flutter.embedding.engine.FlutterJNI.handlePlatformMessage(FlutterJNI.java:2)
	at android.os.MessageQueue.nativePollOnce(Native Method)
	at android.os.MessageQueue.next(MessageQueue.java:326)
	at android.os.Looper.loop(Looper.java:181)
	at android.app.ActivityThread.main(ActivityThread.java:7073)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:494)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:965)
)