### PR TITLE
Manage multiple instance of plugin

### DIFF
--- a/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
+++ b/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
@@ -56,7 +56,8 @@ public class AppsflyerSdkPlugin implements MethodCallHandler, FlutterPlugin, Act
     private static String cachedOnAttributionFailure;
     private static String cachedOnConversionDataFail;
     private static DeepLinkResult cachedDeepLinkResult;
-    
+    private static List<AppsflyerSdkPlugin> instances = new ArrayList<>();
+
     final Handler uiThreadHandler = new Handler(Looper.getMainLooper());
     private EventChannel mEventChannel;
     /**
@@ -168,7 +169,7 @@ public class AppsflyerSdkPlugin implements MethodCallHandler, FlutterPlugin, Act
         mMethodChannel.setMethodCallHandler(this);
         mCallbackChannel = new MethodChannel(messenger, AppsFlyerConstants.AF_CALLBACK_CHANNEL);
         mCallbackChannel.setMethodCallHandler(callbacksHandler);
-
+        instances.add(this);
     }
 
 
@@ -477,7 +478,10 @@ public class AppsflyerSdkPlugin implements MethodCallHandler, FlutterPlugin, Act
                         } catch (JSONException e) {
                             e.printStackTrace();
                         }
-                        mCallbackChannel.invokeMethod("callListener", args.toString());
+
+                        for (AppsflyerSdkPlugin instance : instances) {
+                            instance.mCallbackChannel.invokeMethod("callListener", args.toString());
+                        }
                     }
                 }
         );
@@ -776,8 +780,11 @@ public class AppsflyerSdkPlugin implements MethodCallHandler, FlutterPlugin, Act
     public void onDetachedFromEngine(FlutterPluginBinding binding) {
         mMethodChannel.setMethodCallHandler(null);
         mMethodChannel = null;
+        mCallbackChannel.setMethodCallHandler(null);
+        mCallbackChannel = null;
         mEventChannel.setStreamHandler(null);
         mEventChannel = null;
+        instances.remove(this);
     }
 
     @Override


### PR DESCRIPTION
## Issue

When this plugin is used together with `package:firebase_messaging`, it creates multiple instances of the plugin. Why? because `firebase_messaging` creates a new `FlutterEngine` which in turn registers the plugin for the second time thus creating a new instance. This would also be the case when using multiple `FlutterEngine`s anyway.

Before this change, when the app is placed in the background using the back button, the initial instance even though alive contains an already detached instance of the engine hence the messenger initialized with the instance's MethodChannel is detached from the framework and as such the callbacks are never called. This is a leak I currently could not track down with limited time.

## Resolution

Even though I might consider this level of instance book-keeping somewhat of a "hack", I actually found a similar pattern from other plugins like [audio_session](https://pub.dev/packages/audio_session). I could spend for time investigating the leak but for now, I only have this as a quick solution.

I believe the listeners are only created once in the init phase on the native SDK, I can't tell as it isn't OSS but it would be nice if that could be resync somehow. 

It might also be related to 
https://github.com/AppsFlyerSDK/appsflyer-flutter-plugin/issues/172 https://github.com/AppsFlyerSDK/appsflyer-flutter-plugin/issues/141 https://github.com/AppsFlyerSDK/appsflyer-flutter-plugin/issues/109