### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ appsflyerSdk.initSdk(
     registerOnDeepLinkingCallback: true
 );
 ```
+  
+Add this snippet in the main() method to register installations  
+```dart
+appsflyerSdk.onInstallConversionData((response){
+    debugPrint('Appsflyer - $response');
+  });
+```  
 
 ---
 


### PR DESCRIPTION
Add a code snippet to register installations. One of the main reasons why I (and others) use the AppsFlyer SDK is to track the success of ads placed on different platforms. The ad partners will always need the number of installations from the ads they have placed on your behalf. Had a hard time resolving issues with my ad partners as I only followed the instructions on the README.md file.