### PR TITLE
Fix typos and tests

### DIFF
--- a/lib/src/appsflyer_invite_link_params.dart
+++ b/lib/src/appsflyer_invite_link_params.dart
@@ -4,7 +4,7 @@ class AppsFlyerInviteLinkParams {
   final String? channel;
   final String? campaign;
   final String? referrerName;
-  final String? referreImageUrl;
+  final String? referrerImageUrl;
   final String? customerID;
   final String? baseDeepLink;
   final String? brandDomain;
@@ -17,7 +17,7 @@ class AppsFlyerInviteLinkParams {
     this.baseDeepLink,
     this.brandDomain,
     this.customerID,
-    this.referreImageUrl,
+    this.referrerImageUrl,
     this.customParams
   });
 }

--- a/lib/src/appsflyer_sdk.dart
+++ b/lib/src/appsflyer_sdk.dart
@@ -346,7 +346,7 @@ class AppsflyerSdk {
       AppsFlyerInviteLinkParams params) {
     Map<String, Object?> inviteLinkParamsMap = <String, Object?>{};
     inviteLinkParamsMap['customParams'] = params.customParams;
-    inviteLinkParamsMap['referrerImageUrl'] = params.referreImageUrl;
+    inviteLinkParamsMap['referrerImageUrl'] = params.referrerImageUrl;
     inviteLinkParamsMap['customerID'] = params.customerID;
     inviteLinkParamsMap['brandDomain'] = params.brandDomain;
     inviteLinkParamsMap['baseDeeplink'] = params.baseDeepLink;

--- a/test/appsflyer_sdk_test.dart
+++ b/test/appsflyer_sdk_test.dart
@@ -64,6 +64,7 @@ void main() {
           case 'setAppInviteOneLinkID':
           case 'generateInviteLink':
           case 'setSharingFilterForAllPartners':
+          case 'setSharingFilterForPartners':
           case 'setSharingFilter':
           case 'getSDKVersion':
           case 'getAppsFlyerUID':
@@ -78,7 +79,6 @@ void main() {
           case 'setAdditionalData':
           case 'waitForCustomerUserId':
           case 'setCustomerUserId':
-          case 'enableLocationCollection':
           case 'setAndroidIdData':
           case 'setImeiData':
           case 'updateServerUninstallToken':
@@ -166,16 +166,22 @@ void main() {
       expect(selectedMethod, 'generateInviteLink');
     });
 
+    test('check setSharingFilterForPartners call', () async {
+      instance.setSharingFilterForPartners(['all']);
+
+      expect(selectedMethod, 'setSharingFilterForPartners');
+    });
+
     test('check setSharingFilterForAllPartners call', () async {
       instance.setSharingFilterForAllPartners();
 
-      expect(selectedMethod, 'setSharingFilterForAllPartners');
+      expect(selectedMethod, 'setSharingFilterForPartners');
     });
 
     test('check setSharingFilter call', () async {
-      instance.setSharingFilter(["filters"]);
+      instance.setSharingFilter(["partners"]);
 
-      expect(selectedMethod, 'setSharingFilter');
+      expect(selectedMethod, 'setSharingFilterForPartners');
     });
 
     test('check getSDKVersion call', () async {
@@ -230,7 +236,7 @@ void main() {
     test('check setUserEmailsWithCryptType call', () async {
       instance.setUserEmails(["emails"], EmailCryptType.EmailCryptTypeNone);
 
-      expect(selectedMethod, 'setUserEmailsWithCryptType');
+      expect(selectedMethod, 'setUserEmails');
     });
 
     test('check setUserEmails call', () async {
@@ -255,12 +261,6 @@ void main() {
       instance.setCustomerUserId("id");
 
       expect(selectedMethod, 'setCustomerUserId');
-    });
-
-    test('check enableLocationCollection call', () async {
-      instance.enableLocationCollection(false);
-
-      expect(selectedMethod, 'enableLocationCollection');
     });
 
     test('check setImeiData call', () async {


### PR DESCRIPTION
**This PR contains the following changes:**

1. Fix a typo in `appsflyer_invite_link_params.dart` and `appsflyer_sdk.dart`:
- `referreImageUrl -> referrerImageUrl`

2. Fix tests for deprecated methods by substituting the expected output with the new methods being called inside.
3. Remove the test for method `enableLocationCollection` that has been removed since `AppsFlyerSDK v6.3.0`.
4. Add new tests for the new methods that replaced the deprecated ones, namely: `setSharingFilterForPartners`.

😀✌️