### PR TITLE
Update to android v6.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Versions
+## 6.12.2
+- update to Android SDK to v6.12.2
 ## 6.11.3
 - null pointer exception fix for android, push notification bug fix & ios sdk 6.11.2
 ## 6.11.2

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ### <a id="plugin-build-for"> This plugin is built for
 
-- Android AppsFlyer SDK **v6.11.2**
+- Android AppsFlyer SDK **v6.12.2**
 - iOS AppsFlyer SDK **v6.11.2**
 
 ## <a id="breaking-changes"> 	❗❗ Breaking changes when updating to v6.x.x❗❗

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,6 +35,6 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.0.0'
-    implementation 'com.appsflyer:af-android-sdk:6.11.2'
+    implementation 'com.appsflyer:af-android-sdk:6.12.2'
     implementation 'com.android.installreferrer:installreferrer:2.1'
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: appsflyer_sdk
 description: A Flutter plugin for AppsFlyer SDK. Supports iOS and Android.
-version: 6.11.3
+version: 6.12.2
 
 homepage: https://github.com/AppsFlyerSDK/flutter_appsflyer_sdk
 


### PR DESCRIPTION
Update to Android SDK v6.11.2 because important [bugfixes](https://support.appsflyer.com/hc/en-us/articles/115001256006-AppsFlyer-Android-SDK-release-notes) are included:

- Fixed a bug that could cause the app to crash on some devices in Android 8.1.0 and Android 11.

The ticket is also about the bug: https://github.com/AppsFlyerSDK/appsflyer-android-app/issues/20