### PR TITLE
Fix Android NullPointerException crash

### DIFF
--- a/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
+++ b/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
@@ -386,7 +386,9 @@ public class AppsflyerSdkPlugin implements MethodCallHandler, FlutterPlugin, Act
                     uiThreadHandler.post(new Runnable() {
                         @Override
                         public void run() {
-                            mMethodChannel.invokeMethod("onSuccess", null);
+                            if (mMethodChannel != null) {
+                                mMethodChannel.invokeMethod("onSuccess", null);
+                            }
                         }
                     });
                 }
@@ -396,10 +398,12 @@ public class AppsflyerSdkPlugin implements MethodCallHandler, FlutterPlugin, Act
                     uiThreadHandler.post(new Runnable() {
                         @Override
                         public void run() {
-                            HashMap<String, Object> errorDetails = new HashMap<>();
-                            errorDetails.put("errorCode", errorCode);
-                            errorDetails.put("errorMessage", errorMessage);
-                            mMethodChannel.invokeMethod("onError", errorDetails);
+                            if (mMethodChannel != null) {
+                                HashMap<String, Object> errorDetails = new HashMap<>();
+                                errorDetails.put("errorCode", errorCode);
+                                errorDetails.put("errorMessage", errorMessage);
+                                mMethodChannel.invokeMethod("onError", errorDetails);
+                            }
                         }
                     });
                 }
@@ -963,8 +967,8 @@ public class AppsflyerSdkPlugin implements MethodCallHandler, FlutterPlugin, Act
         try {
             String monetizationNetwork = requireNonNullArgument(call, "monetizationNetwork");
             String currencyIso4217Code = requireNonNullArgument(call, "currencyIso4217Code");
-            double revenue = requireNonNullArgument(call,"revenue");
-            String mediationNetworkString = requireNonNullArgument(call,"mediationNetwork");
+            double revenue = requireNonNullArgument(call, "revenue");
+            String mediationNetworkString = requireNonNullArgument(call, "mediationNetwork");
 
             MediationNetwork mediationNetwork = MediationNetwork.valueOf(mediationNetworkString.toUpperCase());
 
@@ -984,8 +988,7 @@ public class AppsflyerSdkPlugin implements MethodCallHandler, FlutterPlugin, Act
         } catch (IllegalArgumentException e) {
             // The IllegalArgumentException could come from either requireNonNullArgument or valueOf methods.
             result.error("INVALID_ARGUMENT_PROVIDED", e.getMessage(), null);
-        }
-        catch (Throwable t) {
+        } catch (Throwable t) {
             result.error("UNEXPECTED_ERROR", "[logAdRevenue]: An unexpected error occurred: " + t.getMessage(), null);
             Log.e("AppsFlyer", "Unexpected exception occurred: [logAdRevenue]", t);
         }


### PR DESCRIPTION
Fixed https://github.com/AppsFlyerSDK/appsflyer-flutter-plugin/issues/350 , https://github.com/AppsFlyerSDK/appsflyer-flutter-plugin/issues/347 , https://github.com/AppsFlyerSDK/appsflyer-flutter-plugin/issues/345 .

Crash reason: `mMethodChannel` is destroyed following the lifecycle of the `Activity` hosting Flutter. Specifically, it’s set to null in the `onDetachedFromEngine` method. However, `AppsFlyerLib` appears to be a singleton, meaning its callback timing aligns with the entire app's lifecycle, which creates a chance for `mMethodChannel` to be null.

Crash scenario: This is a hypothetical situation. Before the callback for `AppsFlyerLib.start `executes, the app navigates to a non-Flutter Activity (like in an advertisement scene). At this point, the previous Flutter-hosting Activity is destroyed, possibly due to low memory.