### PR TITLE
[Delivery 63011] Fix Android NullPointerException

### DIFF
--- a/android/src/main/java/com/appsflyer/appsflyersdk/AppsFlyerConstants.java
+++ b/android/src/main/java/com/appsflyer/appsflyersdk/AppsFlyerConstants.java
@@ -1,30 +1,32 @@
 package com.appsflyer.appsflyersdk;
 
-public class AppsFlyerConstants {
-    final static String PLUGIN_VERSION                          = "6.15.1";
-    final static String AF_APP_INVITE_ONE_LINK                  = "appInviteOneLink";
-    final static String AF_HOST_PREFIX                          = "hostPrefix";
-    final static String AF_HOST_NAME                            = "hostName";
-    final static String AF_IS_DEBUG                             = "isDebug";
-    final static String AF_MANUAL_START                         = "manualStart";
-    final static String AF_DEV_KEY                              = "afDevKey";
-    final static String AF_EVENT_NAME                           = "eventName";
-    final static String AF_EVENT_VALUES                         = "eventValues";
-    final static String AF_ON_INSTALL_CONVERSION_DATA_LOADED    = "onInstallConversionDataLoaded";
-    final static String AF_ON_APP_OPEN_ATTRIBUTION              = "onAppOpenAttribution";
-    final static String AF_SUCCESS                              = "success";
-    final static String AF_FAILURE                              = "failure";
-    final static String AF_GCD                                  = "GCD";
-    final static String AF_UDL                                  = "UDL";
-    final static String AF_VALIDATE_PURCHASE                    = "validatePurchase";
-    final static String AF_GCD_CALLBACK                         = "onInstallConversionData";
-    final static String AF_OAOA_CALLBACK                        = "onAppOpenAttribution";
-    final static String AF_UDL_CALLBACK                         = "onDeepLinking";
-    final static String DISABLE_ADVERTISING_IDENTIFIER          = "disableAdvertisingIdentifier";
+public final class AppsFlyerConstants {
+    final static String PLUGIN_VERSION = "6.15.1";
+    final static String AF_APP_INVITE_ONE_LINK = "appInviteOneLink";
+    final static String AF_HOST_PREFIX = "hostPrefix";
+    final static String AF_HOST_NAME = "hostName";
+    final static String AF_IS_DEBUG = "isDebug";
+    final static String AF_MANUAL_START = "manualStart";
+    final static String AF_DEV_KEY = "afDevKey";
+    final static String AF_EVENT_NAME = "eventName";
+    final static String AF_EVENT_VALUES = "eventValues";
+    final static String AF_ON_INSTALL_CONVERSION_DATA_LOADED = "onInstallConversionDataLoaded";
+    final static String AF_ON_APP_OPEN_ATTRIBUTION = "onAppOpenAttribution";
+    final static String AF_SUCCESS = "success";
+    final static String AF_FAILURE = "failure";
+    final static String AF_GCD = "GCD";
+    final static String AF_UDL = "UDL";
+    final static String AF_VALIDATE_PURCHASE = "validatePurchase";
+    final static String AF_GCD_CALLBACK = "onInstallConversionData";
+    final static String AF_OAOA_CALLBACK = "onAppOpenAttribution";
+    final static String AF_UDL_CALLBACK = "onDeepLinking";
+    final static String DISABLE_ADVERTISING_IDENTIFIER = "disableAdvertisingIdentifier";
 
-    final static String AF_EVENTS_CHANNEL                       = "af-events";
-    final static String AF_METHOD_CHANNEL                       = "af-api";
-    final static String AF_CALLBACK_CHANNEL                     = "callbacks";
+    final static String AF_EVENTS_CHANNEL = "af-events";
+    final static String AF_METHOD_CHANNEL = "af-api";
+    final static String AF_CALLBACK_CHANNEL = "callbacks";
 
-    final static String AF_BROADCAST_ACTION_NAME                = "com.appsflyer.appsflyersdk";
+    final static String AF_BROADCAST_ACTION_NAME = "com.appsflyer.appsflyersdk";
+
+    final static String AF_PLUGIN_TAG = "AppsFlyer_FlutterPlugin";
 }

--- a/android/src/main/java/com/appsflyer/appsflyersdk/LogMessages.java
+++ b/android/src/main/java/com/appsflyer/appsflyersdk/LogMessages.java
@@ -1,0 +1,12 @@
+package com.appsflyer.appsflyersdk;
+
+public final class LogMessages {
+
+    // Prevent the instantiation of this utilities class.
+    private LogMessages() {
+        throw new IllegalStateException("LogMessages class should not be instantiated");
+    }
+
+    public static final String METHOD_CHANNEL_IS_NULL = "mMethodChannel is null, cannot invoke the callback";
+    public static final String ACTIVITY_NOT_ATTACHED_TO_ENGINE = "Activity isn't attached to the flutter engine";
+}

--- a/example/lib/home_container.dart
+++ b/example/lib/home_container.dart
@@ -7,12 +7,14 @@ import 'utils.dart';
 class HomeContainer extends StatefulWidget {
   final Map onData;
   final Future<bool?> Function(String, Map) logEvent;
+  final void Function() logAdRevenueEvent;
   Object deepLinkData;
 
   HomeContainer({
     required this.onData,
     required this.deepLinkData,
     required this.logEvent,
+    required this.logAdRevenueEvent,
   });
 
   @override
@@ -127,6 +129,20 @@ class _HomeContainerState extends State<HomeContainer> {
                       });
                     },
                     child: Text("Trigger Purchase Event"),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.white,
+                      padding: EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+                      textStyle: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16,
+                      ),
+                    ),
+                  ),
+                  ElevatedButton(
+                    onPressed: () {
+                      widget.logAdRevenueEvent();
+                    },
+                    child: Text("Trigger AdRevenue Event"),
                     style: ElevatedButton.styleFrom(
                       backgroundColor: Colors.white,
                       padding: EdgeInsets.symmetric(horizontal: 20, vertical: 10),

--- a/example/lib/main_page.dart
+++ b/example/lib/main_page.dart
@@ -124,6 +124,7 @@ class MainPageState extends State<MainPage> {
                     onData: _gcd,
                     deepLinkData: _deepLinkData,
                     logEvent: logEvent,
+                    logAdRevenueEvent: logAdRevenueEvent,
                   ),
                 ),
                 ElevatedButton(
@@ -133,7 +134,8 @@ class MainPageState extends State<MainPage> {
                         showMessage("AppsFlyer SDK initialized successfully.");
                       },
                       onError: (int errorCode, String errorMessage) {
-                        showMessage("Error initializing AppsFlyer SDK: Code $errorCode - $errorMessage");
+                        showMessage(
+                            "Error initializing AppsFlyer SDK: Code $errorCode - $errorMessage");
                       },
                     );
                   },
@@ -158,13 +160,29 @@ class MainPageState extends State<MainPage> {
     return logResult;
   }
 
+  void logAdRevenueEvent() {
+    try {
+      Map<String, String> customParams = {
+        'ad_platform': 'Admob',
+        'ad_currency': 'USD',
+      };
+
+      AdRevenueData adRevenueData = AdRevenueData(
+          monetizationNetwork: 'SpongeBob',
+          mediationNetwork: AFMediationNetwork.googleAdMob.value,
+          currencyIso4217Code: 'USD',
+          revenue: 100.3,
+          additionalParameters: customParams);
+      _appsflyerSdk.logAdRevenue(adRevenueData);
+      print("Ad Revenue event logged with no errors");
+    } catch (e) {
+      print("Failed to log event: $e");
+    }
+  }
+
   void showMessage(String message) {
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(
-      content:
-      Text(message),
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text(message),
     ));
   }
 }
-
-

--- a/ios/Classes/AppsflyerSdkPlugin.m
+++ b/ios/Classes/AppsflyerSdkPlugin.m
@@ -255,20 +255,20 @@ static BOOL _isSKADEnabled = false;
 
 - (AppsFlyerAdRevenueMediationNetworkType)getEnumValueFromString:(NSString *)mediationNetworkString {
     NSDictionary<NSString *, NSNumber *> *stringToEnumMap = @{
-        @"googleadmob": @(AppsFlyerAdRevenueMediationNetworkTypeGoogleAdMob),
+        @"google_admob": @(AppsFlyerAdRevenueMediationNetworkTypeGoogleAdMob),
         @"ironsource": @(AppsFlyerAdRevenueMediationNetworkTypeIronSource),
-        @"applovinmax": @(AppsFlyerAdRevenueMediationNetworkTypeApplovinMax),
+        @"applovin_max": @(AppsFlyerAdRevenueMediationNetworkTypeApplovinMax),
         @"fyber": @(AppsFlyerAdRevenueMediationNetworkTypeFyber),
         @"appodeal": @(AppsFlyerAdRevenueMediationNetworkTypeAppodeal),
-        @"Admost": @(AppsFlyerAdRevenueMediationNetworkTypeAdmost),
-        @"Topon": @(AppsFlyerAdRevenueMediationNetworkTypeTopon),
-        @"Tradplus": @(AppsFlyerAdRevenueMediationNetworkTypeTradplus),
-        @"Yandex": @(AppsFlyerAdRevenueMediationNetworkTypeYandex),
+        @"admost": @(AppsFlyerAdRevenueMediationNetworkTypeAdmost),
+        @"topon": @(AppsFlyerAdRevenueMediationNetworkTypeTopon),
+        @"tradplus": @(AppsFlyerAdRevenueMediationNetworkTypeTradplus),
+        @"yandex": @(AppsFlyerAdRevenueMediationNetworkTypeYandex),
         @"chartboost": @(AppsFlyerAdRevenueMediationNetworkTypeChartBoost),
-        @"Unity": @(AppsFlyerAdRevenueMediationNetworkTypeUnity),
-        @"toponpte": @(AppsFlyerAdRevenueMediationNetworkTypeToponPte),
-        @"customMediation": @(AppsFlyerAdRevenueMediationNetworkTypeCustom),
-        @"directMonetizationNetwork": @(AppsFlyerAdRevenueMediationNetworkTypeDirectMonetization)
+        @"unity": @(AppsFlyerAdRevenueMediationNetworkTypeUnity),
+        @"topon_pte": @(AppsFlyerAdRevenueMediationNetworkTypeToponPte),
+        @"custom_mediation": @(AppsFlyerAdRevenueMediationNetworkTypeCustom),
+        @"direct_monetization_network": @(AppsFlyerAdRevenueMediationNetworkTypeDirectMonetization)
     };
     
     NSNumber *enumValueNumber = stringToEnumMap[mediationNetworkString];

--- a/lib/src/appsflyer_constants.dart
+++ b/lib/src/appsflyer_constants.dart
@@ -49,31 +49,31 @@ enum AFMediationNetwork {
       case AFMediationNetwork.ironSource:
         return "ironsource";
       case AFMediationNetwork.applovinMax:
-        return "applovinmax";
+        return "applovin_max";
       case AFMediationNetwork.googleAdMob:
-        return "googleadmob";
+        return "google_admob";
       case AFMediationNetwork.fyber:
         return "fyber";
       case AFMediationNetwork.appodeal:
         return "appodeal";
       case AFMediationNetwork.admost:
-        return "Admost";
+        return "admost";
       case AFMediationNetwork.topon:
-        return "Topon";
+        return "topon";
       case AFMediationNetwork.tradplus:
-        return "Tradplus";
+        return "tradplus";
       case AFMediationNetwork.yandex:
-        return "Yandex";
+        return "yandex";
       case AFMediationNetwork.chartboost:
         return "chartboost";
       case AFMediationNetwork.unity:
-        return "Unity";
+        return "unity";
       case AFMediationNetwork.toponPte:
-        return "toponpte";
+        return "topon_pte";
       case AFMediationNetwork.customMediation:
-        return "customMediation";
+        return "custom_mediation";
       case AFMediationNetwork.directMonetizationNetwork:
-        return "directMonetizationNetwork";
+        return "direct_monetization_network";
     }
   }
 }


### PR DESCRIPTION
Null checks added that suppose to fix the issue some clients face.
The native Android SDK is lifecycle aware, hence when for some reason Flutter Activity is detached then `mMethodChannel` is set to null and the native SDK didn't start yet then `AppsFlyerRequestListener()` will result an `onError` callback which will throw `NullPointerException`.