### PR TITLE
This should fix the NullPointerException

### DIFF
--- a/android/src/main/java/com/appsflyer/appsflyersdk/AppsFlyerConstants.java
+++ b/android/src/main/java/com/appsflyer/appsflyersdk/AppsFlyerConstants.java
@@ -1,30 +1,32 @@
 package com.appsflyer.appsflyersdk;
 
-public class AppsFlyerConstants {
-    final static String PLUGIN_VERSION                          = "6.15.1";
-    final static String AF_APP_INVITE_ONE_LINK                  = "appInviteOneLink";
-    final static String AF_HOST_PREFIX                          = "hostPrefix";
-    final static String AF_HOST_NAME                            = "hostName";
-    final static String AF_IS_DEBUG                             = "isDebug";
-    final static String AF_MANUAL_START                         = "manualStart";
-    final static String AF_DEV_KEY                              = "afDevKey";
-    final static String AF_EVENT_NAME                           = "eventName";
-    final static String AF_EVENT_VALUES                         = "eventValues";
-    final static String AF_ON_INSTALL_CONVERSION_DATA_LOADED    = "onInstallConversionDataLoaded";
-    final static String AF_ON_APP_OPEN_ATTRIBUTION              = "onAppOpenAttribution";
-    final static String AF_SUCCESS                              = "success";
-    final static String AF_FAILURE                              = "failure";
-    final static String AF_GCD                                  = "GCD";
-    final static String AF_UDL                                  = "UDL";
-    final static String AF_VALIDATE_PURCHASE                    = "validatePurchase";
-    final static String AF_GCD_CALLBACK                         = "onInstallConversionData";
-    final static String AF_OAOA_CALLBACK                        = "onAppOpenAttribution";
-    final static String AF_UDL_CALLBACK                         = "onDeepLinking";
-    final static String DISABLE_ADVERTISING_IDENTIFIER          = "disableAdvertisingIdentifier";
+public final class AppsFlyerConstants {
+    final static String PLUGIN_VERSION = "6.15.1";
+    final static String AF_APP_INVITE_ONE_LINK = "appInviteOneLink";
+    final static String AF_HOST_PREFIX = "hostPrefix";
+    final static String AF_HOST_NAME = "hostName";
+    final static String AF_IS_DEBUG = "isDebug";
+    final static String AF_MANUAL_START = "manualStart";
+    final static String AF_DEV_KEY = "afDevKey";
+    final static String AF_EVENT_NAME = "eventName";
+    final static String AF_EVENT_VALUES = "eventValues";
+    final static String AF_ON_INSTALL_CONVERSION_DATA_LOADED = "onInstallConversionDataLoaded";
+    final static String AF_ON_APP_OPEN_ATTRIBUTION = "onAppOpenAttribution";
+    final static String AF_SUCCESS = "success";
+    final static String AF_FAILURE = "failure";
+    final static String AF_GCD = "GCD";
+    final static String AF_UDL = "UDL";
+    final static String AF_VALIDATE_PURCHASE = "validatePurchase";
+    final static String AF_GCD_CALLBACK = "onInstallConversionData";
+    final static String AF_OAOA_CALLBACK = "onAppOpenAttribution";
+    final static String AF_UDL_CALLBACK = "onDeepLinking";
+    final static String DISABLE_ADVERTISING_IDENTIFIER = "disableAdvertisingIdentifier";
 
-    final static String AF_EVENTS_CHANNEL                       = "af-events";
-    final static String AF_METHOD_CHANNEL                       = "af-api";
-    final static String AF_CALLBACK_CHANNEL                     = "callbacks";
+    final static String AF_EVENTS_CHANNEL = "af-events";
+    final static String AF_METHOD_CHANNEL = "af-api";
+    final static String AF_CALLBACK_CHANNEL = "callbacks";
 
-    final static String AF_BROADCAST_ACTION_NAME                = "com.appsflyer.appsflyersdk";
+    final static String AF_BROADCAST_ACTION_NAME = "com.appsflyer.appsflyersdk";
+
+    final static String AF_PLUGIN_TAG = "AppsFlyer_FlutterPlugin";
 }

--- a/android/src/main/java/com/appsflyer/appsflyersdk/LogMessages.java
+++ b/android/src/main/java/com/appsflyer/appsflyersdk/LogMessages.java
@@ -1,0 +1,12 @@
+package com.appsflyer.appsflyersdk;
+
+public final class LogMessages {
+
+    // Prevent the instantiation of this utilities class.
+    private LogMessages() {
+        throw new IllegalStateException("LogMessages class should not be instantiated");
+    }
+
+    public static final String METHOD_CHANNEL_IS_NULL = "mMethodChannel is null, cannot invoke the callback";
+    public static final String ACTIVITY_NOT_ATTACHED_TO_ENGINE = "Activity isn't attached to the flutter engine";
+}


### PR DESCRIPTION
Null checks added that suppose to fix the issue some clients face.
The native Android SDK is lifecycle aware, hence when for some reason Flutter Activity is detached then (mMethodChannel is set to null) and the native SDK didn't start yet then AppsFlyerRequestListener() will result an onError callback which will throw NullPointerException.