### PR TITLE
Immediate usfull actions to prevent NullPointerExceptions that stem from race conditions on callback triggers

### DIFF
--- a/android/src/main/java/com/appsflyer/appsflyersdk/LogMessages.java
+++ b/android/src/main/java/com/appsflyer/appsflyersdk/LogMessages.java
@@ -10,4 +10,5 @@ public final class LogMessages {
     public static final String METHOD_CHANNEL_IS_NULL = "mMethodChannel is null, cannot invoke the callback";
     public static final String ACTIVITY_NOT_ATTACHED_TO_ENGINE = "Activity isn't attached to the flutter engine";
     public static final String ERROR_WHILE_SETTING_CONSENT = "Error while setting consent data: ";
+    public static final String AF_DEV_KEY_IS_EMPTY = "AppsFlyer dev key is empty";
 }


### PR DESCRIPTION
1. Fixed `startSDKwithHandler()` method: Null checks moved inside lambda execution
2. Fixed `runOnUIThread()` method: Added null check for `mCallbackChannel`.
3. Immediately return `initSdk` method when dev key is missing.

Fixes #398 #329 
