### PR TITLE
hotfix: remove -rc1 suffix from version 6.17.8

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: appsflyer_sdk
 description: A Flutter plugin for AppsFlyer SDK. Supports iOS and Android.
-version: 6.17.8-rc1
+version: 6.17.8
 
 homepage: https://github.com/AppsFlyerSDK/flutter_appsflyer_sdk
 


### PR DESCRIPTION
Version in `pubspec.yaml` was incorrectly merged with RC suffix. This fixes the version to be production-ready.