### PR TITLE
Fix issue does not handle deeplink when open app with OneLink with UISceneDelegate

### DIFF
--- a/ios/Classes/AppsflyerSdkPlugin.h
+++ b/ios/Classes/AppsflyerSdkPlugin.h
@@ -6,11 +6,7 @@
 #import "AppsFlyerLib.h"
 #endif
 
-#if __has_include(<Flutter/FlutterSceneLifeCycleDelegate.h>)
 @interface AppsflyerSdkPlugin: NSObject<FlutterPlugin, FlutterSceneLifeCycleDelegate>
-#else
-@interface AppsflyerSdkPlugin: NSObject<FlutterPlugin>
-#endif
 
 @property (readwrite, nonatomic) BOOL isManualStart;
 

--- a/ios/Classes/AppsflyerSdkPlugin.m
+++ b/ios/Classes/AppsflyerSdkPlugin.m
@@ -970,33 +970,14 @@ static BOOL _isSKADEnabled = false;
 #if __has_include(<Flutter/FlutterSceneLifeCycleDelegate.h>)
 #pragma mark - FlutterSceneLifeCycleDelegate
 
-// UIScene-based URI-scheme deep links (iOS 13+, Flutter 3.41+ UIScene migration)
-- (BOOL)scene:(UIScene*)scene openURLContexts:(NSSet<UIOpenURLContext*>*)URLContexts API_AVAILABLE(ios(13.0)) {
-    for (UIOpenURLContext *context in URLContexts) {
-        NSDictionary *opts = @{};
-        if (context.options.sourceApplication) {
-            opts = @{UIApplicationOpenURLOptionsSourceApplicationKey: context.options.sourceApplication};
-        }
-        [[AppsFlyerAttribution shared] handleOpenUrl:context.URL options:opts];
-    }
-    return NO;
-}
-
 // Cold-start deep links delivered via UISceneConnectionOptions (iOS 13+)
-// Handles both URI-scheme links (URLContexts) and Universal Links (userActivities)
 - (BOOL)scene:(UIScene*)scene
     willConnectToSession:(UISceneSession*)session
-                 options:(UISceneConnectionOptions*)connectionOptions API_AVAILABLE(ios(13.0)) {
-    for (UIOpenURLContext *context in connectionOptions.URLContexts) {
-        NSDictionary *opts = @{};
-        if (context.options.sourceApplication) {
-            opts = @{UIApplicationOpenURLOptionsSourceApplicationKey: context.options.sourceApplication};
-        }
-        [[AppsFlyerAttribution shared] handleOpenUrl:context.URL options:opts];
-    }
-    for (NSUserActivity *activity in connectionOptions.userActivities) {
-        if ([activity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
-            [[AppsFlyerAttribution shared] continueUserActivity:activity restorationHandler:nil];
+                 options:(nullable UISceneConnectionOptions*)connectionOptions API_AVAILABLE(ios(13.0)) {
+    if ([scene isKindOfClass:[UIWindowScene class]]) {
+        NSUserActivity *userActivity = connectionOptions.userActivities.allObjects.firstObject;
+        if (userActivity) {
+            [self scene:scene continueUserActivity:userActivity];
         }
     }
     return NO;

--- a/ios/Classes/AppsflyerSdkPlugin.m
+++ b/ios/Classes/AppsflyerSdkPlugin.m
@@ -68,11 +68,9 @@ static BOOL _isSKADEnabled = false;
     [registrar addMethodCallDelegate:instance channel:channel];
     [registrar addMethodCallDelegate:instance channel:callbackChannel];
     [registrar addApplicationDelegate:instance];
-#if __has_include(<Flutter/FlutterSceneLifeCycleDelegate.h>)
     if (@available(iOS 13.0, *)) {
         [registrar addSceneDelegate:instance];
     }
-#endif
 
 }
 
@@ -967,9 +965,6 @@ static BOOL _isSKADEnabled = false;
     return NO;
 }
 
-#if __has_include(<Flutter/FlutterSceneLifeCycleDelegate.h>)
-#pragma mark - FlutterSceneLifeCycleDelegate
-
 // Cold-start deep links delivered via UISceneConnectionOptions (iOS 13+)
 - (BOOL)scene:(UIScene*)scene
     willConnectToSession:(UISceneSession*)session
@@ -988,7 +983,5 @@ static BOOL _isSKADEnabled = false;
     [[AppsFlyerAttribution shared] continueUserActivity:userActivity restorationHandler:nil];
     return NO;
 }
-#endif // __has_include(<Flutter/FlutterSceneLifeCycleDelegate.h>)
-
 
 @end


### PR DESCRIPTION
Follow the [migration guide for Flutter plugins]( https://docs.flutter.dev/release/breaking-changes/uiscenedelegate#migration-guide-for-flutter-plugins) and [AppsFlyer guide](https://dev.appsflyer.com/hc/docs/app-clip-sdk-integration#:~:text=Add%20the%20following%20code%20to%20sceneDelegate%3A) to support UISceneDelegate