### PR TITLE
Update iOS SDK to 6.17.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Versions
 
+## 6.17.9
+
+- Updated iOS SDK from 6.17.8 to 6.17.9
+- Updated iOS Purchase Connector from 6.17.8 to 6.17.9
+
 ## 6.17.8
 
 - Updated Android SDK from 6.17.4 to 6.17.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Versions
 
-## 6.17.9
+## 6.17.8+1
 
 - Updated iOS SDK from 6.17.8 to 6.17.9
 - Updated iOS Purchase Connector from 6.17.8 to 6.17.9

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ To do so, please follow [this article](https://support.appsflyer.com/hc/en-us/ar
 ## SDK Versions
 
 - Android AppsFlyer SDK **v6.17.5**
-- iOS AppsFlyer SDK **v6.17.8**
+- iOS AppsFlyer SDK **v6.17.9**
 
 ### Purchase Connector versions
 
 - Android 2.2.0
-- iOS 6.17.8
+- iOS 6.17.9
 
 ## ❗❗ Breaking changes when updating to v6.x.x❗❗
 

--- a/android/src/main/java/com/appsflyer/appsflyersdk/AppsFlyerConstants.java
+++ b/android/src/main/java/com/appsflyer/appsflyersdk/AppsFlyerConstants.java
@@ -1,7 +1,7 @@
 package com.appsflyer.appsflyersdk;
 
 public final class AppsFlyerConstants {
-    final static String PLUGIN_VERSION = "6.17.8";
+    final static String PLUGIN_VERSION = "6.17.9";
     final static String AF_APP_INVITE_ONE_LINK = "appInviteOneLink";
     final static String AF_HOST_PREFIX = "hostPrefix";
     final static String AF_HOST_NAME = "hostName";

--- a/ios/Classes/AppsflyerSdkPlugin.h
+++ b/ios/Classes/AppsflyerSdkPlugin.h
@@ -18,7 +18,7 @@
 @end
 
 // Appsflyer JS objects
-#define kAppsFlyerPluginVersion             @"6.17.8"
+#define kAppsFlyerPluginVersion             @"6.17.9"
 #define afDevKey                            @"afDevKey"
 #define afAppId                             @"afAppId"
 #define afIsDebug                           @"isDebug"

--- a/ios/appsflyer_sdk.podspec
+++ b/ios/appsflyer_sdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'appsflyer_sdk'
-  s.version          = '6.17.8'
+  s.version          = '6.17.9'
   s.summary          = 'AppsFlyer Integration for Flutter'
   s.description      = 'AppsFlyer is the market leader in mobile advertising attribution & analytics, helping marketers to pinpoint their targeting, optimize their ad spend and boost their ROI.'
   s.homepage         = 'https://github.com/AppsFlyerSDK/flutter_appsflyer_sdk'
@@ -21,12 +21,12 @@ Pod::Spec.new do |s|
     ss.source_files = 'Classes/**/*'
     ss.public_header_files = 'Classes/**/*.h'
     ss.dependency 'Flutter'
-    ss.ios.dependency 'AppsFlyerFramework','6.17.8'
+    ss.ios.dependency 'AppsFlyerFramework','6.17.9'
   end
 
   s.subspec 'PurchaseConnector' do |ss|
     ss.dependency 'Flutter'
-    ss.ios.dependency 'PurchaseConnector', '6.17.8'
+    ss.ios.dependency 'PurchaseConnector', '6.17.9'
     ss.source_files = 'PurchaseConnector/**/*'
     ss.public_header_files = 'PurchaseConnector/**/*.h'
   

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: appsflyer_sdk
 description: A Flutter plugin for AppsFlyer SDK. Supports iOS and Android.
-version: 6.17.9
+version: 6.17.8+1
 
 homepage: https://github.com/AppsFlyerSDK/flutter_appsflyer_sdk
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: appsflyer_sdk
 description: A Flutter plugin for AppsFlyer SDK. Supports iOS and Android.
-version: 6.17.8
+version: 6.17.9
 
 homepage: https://github.com/AppsFlyerSDK/flutter_appsflyer_sdk
 


### PR DESCRIPTION
## Summary
- Updated iOS AppsFlyer SDK from 6.17.8 to 6.17.9
- Updated iOS Purchase Connector from 6.17.8 to 6.17.9
- Bumped plugin version to 6.17.9

## Changed files
- `pubspec.yaml` - plugin version
- `ios/appsflyer_sdk.podspec` - podspec version, AppsFlyerFramework & PurchaseConnector dependencies
- `ios/Classes/AppsflyerSdkPlugin.h` - plugin version constant
- `android/src/main/java/com/appsflyer/appsflyersdk/AppsFlyerConstants.java` - plugin version constant
- `README.md` - SDK version references
- `CHANGELOG.md` - new version entry

## Test plan
- [ ] Verify iOS build compiles with new SDK version
- [ ] Run existing test suite
- [ ] Verify SDK initialization on iOS device/simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)