### PR TITLE
fix(ios): adopt FlutterSceneLifeCycleDelegate for UIScene deep link support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,19 +164,26 @@ jobs:
         working-directory: example
         run: flutter pub get
       
-      # Step 7: Build Android APK (debug mode)
+      # Step 7: Create dummy .env file for CI (not committed to repo)
+      - name: 🔑 Create dummy .env for CI build
+        working-directory: example
+        run: |
+          echo "DEV_KEY=dummy_dev_key" > .env
+          echo "APP_ID=dummy_app_id" >> .env
+
+      # Step 8: Build Android APK (debug mode)
       # This validates that the plugin integrates correctly with Android
       - name: 🔨 Build Android APK (debug)
         working-directory: example
         run: flutter build apk --debug
       
-      # Step 8: Build Android App Bundle (release mode, no signing)
+      # Step 9: Build Android App Bundle (release mode, no signing)
       # App Bundle is the preferred format for Play Store
       - name: 🔨 Build Android App Bundle (release)
         working-directory: example
         run: flutter build appbundle --release
-      
-      # Step 9: Upload build artifacts (optional)
+
+      # Step 10: Upload build artifacts (optional)
       # Useful for manual testing or archiving
       - name: 📤 Upload APK artifact
         if: success()
@@ -239,19 +246,26 @@ jobs:
         working-directory: example/ios
         run: pod install
       
-      # Step 8: Build for iOS Simulator (fastest iOS build)
+      # Step 8: Create dummy .env file for CI (not committed to repo)
+      - name: 🔑 Create dummy .env for CI build
+        working-directory: example
+        run: |
+          echo "DEV_KEY=dummy_dev_key" > .env
+          echo "APP_ID=dummy_app_id" >> .env
+
+      # Step 9: Build for iOS Simulator (fastest iOS build)
       # Validates that the plugin compiles for iOS
       - name: 🔨 Build iOS for Simulator
         working-directory: example
         run: flutter build ios --simulator --debug
       
-      # Step 9: Build iOS IPA without code signing (release mode)
+      # Step 10: Build iOS IPA without code signing (release mode)
       # This validates a full release build without requiring certificates
       - name: 🔨 Build iOS IPA (no codesign)
         working-directory: example
         run: flutter build ipa --release --no-codesign
-      
-      # Step 10: Upload build artifacts (optional)
+
+      # Step 11: Upload build artifacts (optional)
       - name: 📤 Upload iOS build artifact
         if: success()
         uses: actions/upload-artifact@v4

--- a/ios/Classes/AppsflyerSdkPlugin.h
+++ b/ios/Classes/AppsflyerSdkPlugin.h
@@ -6,7 +6,11 @@
 #import "AppsFlyerLib.h"
 #endif
 
+#if __has_include(<Flutter/FlutterSceneLifeCycleDelegate.h>)
 @interface AppsflyerSdkPlugin: NSObject<FlutterPlugin, FlutterSceneLifeCycleDelegate>
+#else
+@interface AppsflyerSdkPlugin: NSObject<FlutterPlugin>
+#endif
 
 @property (readwrite, nonatomic) BOOL isManualStart;
 

--- a/ios/Classes/AppsflyerSdkPlugin.h
+++ b/ios/Classes/AppsflyerSdkPlugin.h
@@ -6,7 +6,7 @@
 #import "AppsFlyerLib.h"
 #endif
 
-@interface AppsflyerSdkPlugin: NSObject<FlutterPlugin>
+@interface AppsflyerSdkPlugin: NSObject<FlutterPlugin, FlutterSceneLifeCycleDelegate>
 
 @property (readwrite, nonatomic) BOOL isManualStart;
 
@@ -18,7 +18,7 @@
 @end
 
 // Appsflyer JS objects
-#define kAppsFlyerPluginVersion             @"6.17.8"
+#define kAppsFlyerPluginVersion             @"6.17.9"
 #define afDevKey                            @"afDevKey"
 #define afAppId                             @"afAppId"
 #define afIsDebug                           @"isDebug"

--- a/ios/Classes/AppsflyerSdkPlugin.m
+++ b/ios/Classes/AppsflyerSdkPlugin.m
@@ -906,9 +906,20 @@ static BOOL _isSKADEnabled = false;
 
 
 + (FlutterViewController*) getViewController{
-    UIViewController *topMostViewControllerObj =  [[[UIApplication sharedApplication] delegate] window].rootViewController;
+    UIWindow *window = nil;
+    if (@available(iOS 13.0, *)) {
+        for (UIWindowScene *scene in [UIApplication sharedApplication].connectedScenes) {
+            if (scene.activationState == UISceneActivationStateForegroundActive) {
+                window = scene.windows.firstObject;
+                break;
+            }
+        }
+    }
+    if (window == nil) {
+        window = [[[UIApplication sharedApplication] delegate] window];
+    }
+    UIViewController *topMostViewControllerObj = window.rootViewController;
     FlutterViewController *flutterViewController = (FlutterViewController *)topMostViewControllerObj;
-    
     return flutterViewController;
 }
 

--- a/ios/Classes/AppsflyerSdkPlugin.m
+++ b/ios/Classes/AppsflyerSdkPlugin.m
@@ -68,9 +68,11 @@ static BOOL _isSKADEnabled = false;
     [registrar addMethodCallDelegate:instance channel:channel];
     [registrar addMethodCallDelegate:instance channel:callbackChannel];
     [registrar addApplicationDelegate:instance];
+#if __has_include(<Flutter/FlutterSceneLifeCycleDelegate.h>)
     if (@available(iOS 13.0, *)) {
         [registrar addSceneDelegate:instance];
     }
+#endif
 
 }
 
@@ -965,6 +967,7 @@ static BOOL _isSKADEnabled = false;
     return NO;
 }
 
+#if __has_include(<Flutter/FlutterSceneLifeCycleDelegate.h>)
 #pragma mark - FlutterSceneLifeCycleDelegate
 
 // UIScene-based URI-scheme deep links (iOS 13+, Flutter 3.41+ UIScene migration)
@@ -990,6 +993,7 @@ static BOOL _isSKADEnabled = false;
     [[AppsFlyerAttribution shared] continueUserActivity:userActivity restorationHandler:nil];
     return NO;
 }
+#endif // __has_include(<Flutter/FlutterSceneLifeCycleDelegate.h>)
 
 
 @end

--- a/ios/Classes/AppsflyerSdkPlugin.m
+++ b/ios/Classes/AppsflyerSdkPlugin.m
@@ -973,17 +973,31 @@ static BOOL _isSKADEnabled = false;
 // UIScene-based URI-scheme deep links (iOS 13+, Flutter 3.41+ UIScene migration)
 - (BOOL)scene:(UIScene*)scene openURLContexts:(NSSet<UIOpenURLContext*>*)URLContexts API_AVAILABLE(ios(13.0)) {
     for (UIOpenURLContext *context in URLContexts) {
-        [[AppsFlyerAttribution shared] handleOpenUrl:context.URL options:@{}];
+        NSDictionary *opts = @{};
+        if (context.options.sourceApplication) {
+            opts = @{UIApplicationOpenURLOptionsSourceApplicationKey: context.options.sourceApplication};
+        }
+        [[AppsFlyerAttribution shared] handleOpenUrl:context.URL options:opts];
     }
     return NO;
 }
 
-// Cold-start URI-scheme deep links delivered via UISceneConnectionOptions (iOS 13+)
+// Cold-start deep links delivered via UISceneConnectionOptions (iOS 13+)
+// Handles both URI-scheme links (URLContexts) and Universal Links (userActivities)
 - (BOOL)scene:(UIScene*)scene
     willConnectToSession:(UISceneSession*)session
                  options:(UISceneConnectionOptions*)connectionOptions API_AVAILABLE(ios(13.0)) {
     for (UIOpenURLContext *context in connectionOptions.URLContexts) {
-        [[AppsFlyerAttribution shared] handleOpenUrl:context.URL options:@{}];
+        NSDictionary *opts = @{};
+        if (context.options.sourceApplication) {
+            opts = @{UIApplicationOpenURLOptionsSourceApplicationKey: context.options.sourceApplication};
+        }
+        [[AppsFlyerAttribution shared] handleOpenUrl:context.URL options:opts];
+    }
+    for (NSUserActivity *activity in connectionOptions.userActivities) {
+        if ([activity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
+            [[AppsFlyerAttribution shared] continueUserActivity:activity restorationHandler:nil];
+        }
     }
     return NO;
 }

--- a/ios/Classes/AppsflyerSdkPlugin.m
+++ b/ios/Classes/AppsflyerSdkPlugin.m
@@ -68,7 +68,9 @@ static BOOL _isSKADEnabled = false;
     [registrar addMethodCallDelegate:instance channel:channel];
     [registrar addMethodCallDelegate:instance channel:callbackChannel];
     [registrar addApplicationDelegate:instance];
-    
+    if (@available(iOS 13.0, *)) {
+        [registrar addSceneDelegate:instance];
+    }
 
 }
 
@@ -947,8 +949,34 @@ static BOOL _isSKADEnabled = false;
 // Open Universal Links
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler {
     [[AppsFlyerAttribution shared] continueUserActivity:userActivity restorationHandler:restorationHandler];
-    
+
     // Results of this are ORed and NO doesn't affect other delegate interceptors' result.
+    return NO;
+}
+
+#pragma mark - FlutterSceneLifeCycleDelegate
+
+// UIScene-based URI-scheme deep links (iOS 13+, Flutter 3.41+ UIScene migration)
+- (BOOL)scene:(UIScene*)scene openURLContexts:(NSSet<UIOpenURLContext*>*)URLContexts API_AVAILABLE(ios(13.0)) {
+    for (UIOpenURLContext *context in URLContexts) {
+        [[AppsFlyerAttribution shared] handleOpenUrl:context.URL options:@{}];
+    }
+    return NO;
+}
+
+// Cold-start URI-scheme deep links delivered via UISceneConnectionOptions (iOS 13+)
+- (BOOL)scene:(UIScene*)scene
+    willConnectToSession:(UISceneSession*)session
+                 options:(UISceneConnectionOptions*)connectionOptions API_AVAILABLE(ios(13.0)) {
+    for (UIOpenURLContext *context in connectionOptions.URLContexts) {
+        [[AppsFlyerAttribution shared] handleOpenUrl:context.URL options:@{}];
+    }
+    return NO;
+}
+
+// UIScene-based Universal Links (iOS 13+)
+- (BOOL)scene:(UIScene*)scene continueUserActivity:(NSUserActivity*)userActivity API_AVAILABLE(ios(13.0)) {
+    [[AppsFlyerAttribution shared] continueUserActivity:userActivity restorationHandler:nil];
     return NO;
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/AppsFlyerSDK/flutter_appsflyer_sdk
 
 environment:
   sdk: '>=2.17.0 <4.0.0'
-  flutter: ">=3.38.0"
+  flutter: ">=1.10.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/AppsFlyerSDK/flutter_appsflyer_sdk
 
 environment:
   sdk: '>=2.17.0 <4.0.0'
-  flutter: ">=1.10.0"
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary

Fixes deep link breakage on iOS apps using Flutter 3.41+ (DELIVERY-114618).

## Problem

Flutter 3.41 auto-migrates apps to UIScene by default. When UIScene is active, UIKit routes deep links through the scene delegate (`scene:openURLContexts:`, `scene:willConnectToSession:options:`) rather than the traditional AppDelegate methods (`application:openURL:options:`). The plugin only implemented the AppDelegate path, causing deep links to be silently dropped.

## Fix

`AppsflyerSdkPlugin` now conforms to `FlutterSceneLifeCycleDelegate` and registers via `[registrar addSceneDelegate:instance]` (iOS 13+). Three new methods added:

- `scene:willConnectToSession:options:` — cold-start URI-scheme deep links
- `scene:openURLContexts:` — warm-start URI-scheme deep links
- `scene:continueUserActivity:` — Universal Links via UIScene

No app-side changes required.

## Testing

- Reproduced the bug on iOS 18.4 simulator + Flutter 3.41.4 (confirmed broken delegate chain via system logs)
- Verified fix: `scene:willConnectToSession:options:` fires before `startSDK`, `onDeepLinking Status.FOUND` delivered correctly
- Full E2E: 40/40 checks passed (Android + iOS 18.4, all 3 phases)

Fixes: DELIVERY-114618