### PR TITLE
fix(ios): correct FlutterSceneLifeCycle header for UIScene deep link support

### DIFF
--- a/ios/Classes/AppsflyerSdkPlugin.h
+++ b/ios/Classes/AppsflyerSdkPlugin.h
@@ -6,7 +6,11 @@
 #import "AppsFlyerLib.h"
 #endif
 
-#if __has_include(<Flutter/FlutterSceneLifeCycleDelegate.h>)
+#if __has_include(<Flutter/FlutterSceneLifeCycle.h>)
+#import <Flutter/FlutterSceneLifeCycle.h>
+#endif
+
+#if __has_include(<Flutter/FlutterSceneLifeCycle.h>)
 @interface AppsflyerSdkPlugin: NSObject<FlutterPlugin, FlutterSceneLifeCycleDelegate>
 #else
 @interface AppsflyerSdkPlugin: NSObject<FlutterPlugin>

--- a/ios/Classes/AppsflyerSdkPlugin.m
+++ b/ios/Classes/AppsflyerSdkPlugin.m
@@ -68,7 +68,7 @@ static BOOL _isSKADEnabled = false;
     [registrar addMethodCallDelegate:instance channel:channel];
     [registrar addMethodCallDelegate:instance channel:callbackChannel];
     [registrar addApplicationDelegate:instance];
-#if __has_include(<Flutter/FlutterSceneLifeCycleDelegate.h>)
+#if __has_include(<Flutter/FlutterSceneLifeCycle.h>)
     if (@available(iOS 13.0, *)) {
         [registrar addSceneDelegate:instance];
     }
@@ -967,7 +967,7 @@ static BOOL _isSKADEnabled = false;
     return NO;
 }
 
-#if __has_include(<Flutter/FlutterSceneLifeCycleDelegate.h>)
+#if __has_include(<Flutter/FlutterSceneLifeCycle.h>)
 #pragma mark - FlutterSceneLifeCycleDelegate
 
 // UIScene-based URI-scheme deep links (iOS 13+, Flutter 3.41+ UIScene migration)
@@ -1007,7 +1007,7 @@ static BOOL _isSKADEnabled = false;
     [[AppsFlyerAttribution shared] continueUserActivity:userActivity restorationHandler:nil];
     return NO;
 }
-#endif // __has_include(<Flutter/FlutterSceneLifeCycleDelegate.h>)
+#endif // __has_include(<Flutter/FlutterSceneLifeCycle.h>)
 
 
 @end


### PR DESCRIPTION
## Summary

- Fixes the UIScene lifecycle header check that was preventing deep links from working on iOS 13+ with Flutter's UIScene migration
- The previous implementation checked for a non-existent header (`FlutterSceneLifeCycleDelegate.h`) which caused the UIScene lifecycle support to never compile
- Changed to the correct header (`FlutterSceneLifeCycle.h`)

## Changes

- Fixed `#if __has_include()` check from `FlutterSceneLifeCycleDelegate.h` → `FlutterSceneLifeCycle.h`
- Added proper import for `FlutterSceneLifeCycle.h` when available
- UIScene deep link handling now properly compiles on Flutter 3.41+

## Related

- Fixes DELIVERY-114618
- Related to external PR #435

## Test plan

- [ ] Test deep links via UIScene on iOS 13+ with Flutter 3.41+
- [ ] Verify cold-start Universal Links work
- [ ] Verify URI-scheme deep links work while app is in foreground
- [ ] Verify backwards compatibility with older Flutter versions


