### PR TITLE
DELIVERY-117000 (A/4): Split E2E vs smoke, scaffold RC smoke app, add runner + simulator

### DIFF
--- a/.af-e2e/test-plan.json
+++ b/.af-e2e/test-plan.json
@@ -1,0 +1,227 @@
+{
+  "_meta": {
+    "plan_id": "flutter-e2e",
+    "plugin": "flutter",
+    "version": "1.0.0",
+    "description": "Thorough end-to-end test plan for the AppsFlyer Flutter plugin. Runs against plugin source (appsflyer_sdk: path: ..) in example/. Covers cold launch coverage, background deep link, and foreground deep link. Mapped to E2E-001, E2E-002, E2E-003 in appsflyer-mobile-plugin-tooling/contracts/e2e-test-contract.md.",
+    "platforms": ["android", "ios"],
+    "schema_version": "1.0.0",
+    "tooling_contract_ref": "E2E-001, E2E-002, E2E-003"
+  },
+
+  "config": {
+    "android": {
+      "package_name": "com.appsflyer.appsflyersdkexample",
+      "activity": ".MainActivity",
+      "apk_path": "example/build/app/outputs/flutter-apk/app-debug.apk",
+      "build_cmd": "cd example && flutter build apk --debug"
+    },
+    "ios": {
+      "bundle_id": "com.appsflyer.example",
+      "app_path": "example/build/ios/iphonesimulator/Runner.app",
+      "build_cmd": "cd example && flutter build ios --simulator --debug"
+    }
+  },
+
+  "phases": [
+    {
+      "id": "phase_1",
+      "name": "Cold launch coverage",
+      "scenario_ref": "E2E-001",
+      "description": "Fresh install. Validate SDK startup, pre/post-start APIs, three auto-launched events with HTTP 200, and all standard callbacks.",
+      "requires_fresh_install": true,
+      "wait_after_launch_sec": 25,
+      "checks": [
+        {
+          "id": "sdk_started",
+          "description": "startSDK returns SUCCESS",
+          "type": "log_contains",
+          "pattern": "[AF_QA][startSDK] result: SUCCESS",
+          "fail_action": "abort"
+        },
+        {
+          "id": "is_first_launch_true",
+          "description": "onInstallConversionData fires with is_first_launch=true",
+          "type": "log_contains",
+          "pattern": "[AF_QA][CALLBACK][onInstallConversionData]",
+          "payload_check": {"field": "is_first_launch", "expected": "true"},
+          "fail_action": "abort"
+        },
+        {
+          "id": "pre_start_apis_complete",
+          "description": "Pre-start auto APIs ran",
+          "type": "log_contains",
+          "pattern": "[AF_QA][AUTO_APIS] --- Pre-start auto APIs complete ---",
+          "fail_action": "fail"
+        },
+        {
+          "id": "post_start_apis_complete",
+          "description": "Post-start auto APIs ran",
+          "type": "log_contains",
+          "pattern": "[AF_QA][AUTO_APIS] --- Post-start auto APIs complete ---",
+          "fail_action": "fail"
+        },
+        {
+          "id": "get_sdk_version",
+          "description": "getSDKVersion returns a value",
+          "type": "log_contains",
+          "pattern": "[AF_QA][getSDKVersion] result:",
+          "fail_action": "fail"
+        },
+        {
+          "id": "get_appsflyer_uid",
+          "description": "getAppsFlyerUID returns a value",
+          "type": "log_contains",
+          "pattern": "[AF_QA][getAppsFlyerUID] result:",
+          "fail_action": "fail"
+        },
+        {
+          "id": "event_af_demo_launch",
+          "description": "af_demo_launch event fires",
+          "type": "log_contains",
+          "pattern": "[AF_QA][logEvent(af_demo_launch)] result:",
+          "fail_action": "fail"
+        },
+        {
+          "id": "event_af_purchase",
+          "description": "af_purchase event fires",
+          "type": "log_contains",
+          "pattern": "[AF_QA][logEvent: af_purchase sent] result:",
+          "fail_action": "fail"
+        },
+        {
+          "id": "event_af_content_view",
+          "description": "af_content_view event fires",
+          "type": "log_contains",
+          "pattern": "[AF_QA][logEvent: af_content_view sent] result:",
+          "fail_action": "fail"
+        },
+        {
+          "id": "http_200_count",
+          "description": "At least 3 HTTP 200 responses from AppsFlyer servers",
+          "type": "count_matches",
+          "pattern": "response code:200 OK|response_status=200",
+          "minimum": 3,
+          "fail_action": "fail"
+        },
+        {
+          "id": "on_deep_linking_callback",
+          "description": "onDeepLinking callback fires (NOT_FOUND expected on clean launch)",
+          "type": "log_contains",
+          "pattern": "[AF_QA][CALLBACK][onDeepLinking]",
+          "fail_action": "fail"
+        },
+        {
+          "id": "no_fatal_errors",
+          "description": "No fatal exceptions or SDK start errors in logs",
+          "type": "absent",
+          "patterns": ["Fatal Exception", "FATAL", "[AF_QA][startSDK] error:", "response code:4", "response code:5"],
+          "fail_action": "fail"
+        }
+      ]
+    },
+
+    {
+      "id": "phase_2",
+      "name": "Background deep link",
+      "scenario_ref": "E2E-002",
+      "description": "App is backgrounded after Phase 1 SDK start. Deep link URL brings app back to foreground. onDeepLinking fires with Status.FOUND.",
+      "requires_fresh_install": false,
+      "wait_after_trigger_sec": 5,
+      "deep_link_url": "afexample://deeplink?deep_link_value=qa_deeplink_bg&af_sub1=background_test&pid=testmedia&c=deeplink_test",
+      "pre_actions": {
+        "android": ["adb shell input keyevent KEYCODE_HOME", "sleep 2"],
+        "ios": ["xcrun simctl launch {{UDID}} com.apple.mobilesafari", "sleep 2"]
+      },
+      "trigger": {
+        "android": "adb shell am start -a android.intent.action.VIEW -d \"{{DEEP_LINK_URL}}\"",
+        "ios": "xcrun simctl openurl {{UDID}} \"{{DEEP_LINK_URL}}\""
+      },
+      "checks": [
+        {
+          "id": "deeplink_found",
+          "description": "onDeepLinking fires with Status.FOUND",
+          "type": "log_contains",
+          "pattern": "status=Status.FOUND",
+          "fail_action": "fail"
+        },
+        {
+          "id": "deeplink_value_bg",
+          "description": "deepLinkValue matches qa_deeplink_bg",
+          "type": "log_contains",
+          "pattern": "deepLinkValue=qa_deeplink_bg",
+          "fail_action": "fail"
+        },
+        {
+          "id": "no_fatal_errors",
+          "description": "No fatal exceptions after deep link",
+          "type": "absent",
+          "patterns": ["Fatal Exception", "FATAL"],
+          "fail_action": "fail"
+        }
+      ]
+    },
+
+    {
+      "id": "phase_3",
+      "name": "Foreground deep link",
+      "scenario_ref": "E2E-003",
+      "description": "Fresh install. App is in foreground after SDK start. Brief launcher switch triggers onPause. Deep link brings app back. onDeepLinking fires with Status.FOUND.",
+      "requires_fresh_install": true,
+      "wait_after_launch_sec": 25,
+      "wait_after_trigger_sec": 5,
+      "deep_link_url": "afexample://deeplink?deep_link_value=qa_deeplink_fg&af_sub1=foreground_test&pid=testmedia&c=deeplink_test",
+      "pre_actions": {
+        "android": ["adb shell am start -a android.intent.action.MAIN -c android.intent.category.HOME", "sleep 1"],
+        "ios": ["xcrun simctl launch {{UDID}} com.apple.Preferences", "sleep 1"]
+      },
+      "trigger": {
+        "android": "adb shell am start -a android.intent.action.VIEW -d \"{{DEEP_LINK_URL}}\"",
+        "ios": "xcrun simctl openurl {{UDID}} \"{{DEEP_LINK_URL}}\""
+      },
+      "checks": [
+        {
+          "id": "sdk_started",
+          "description": "startSDK returns SUCCESS on fresh install",
+          "type": "log_contains",
+          "pattern": "[AF_QA][startSDK] result: SUCCESS",
+          "fail_action": "abort"
+        },
+        {
+          "id": "is_first_launch_true",
+          "description": "onInstallConversionData fires with is_first_launch=true before deep link",
+          "type": "log_contains",
+          "pattern": "[AF_QA][CALLBACK][onInstallConversionData]",
+          "payload_check": {"field": "is_first_launch", "expected": "true"},
+          "fail_action": "abort"
+        },
+        {
+          "id": "deeplink_found_fg",
+          "description": "onDeepLinking fires with Status.FOUND after foreground deep link",
+          "type": "log_contains",
+          "pattern": "status=Status.FOUND",
+          "fail_action": "fail"
+        },
+        {
+          "id": "deeplink_value_fg",
+          "description": "deepLinkValue matches qa_deeplink_fg",
+          "type": "log_contains",
+          "pattern": "deepLinkValue=qa_deeplink_fg",
+          "fail_action": "fail"
+        },
+        {
+          "id": "no_fatal_errors",
+          "description": "No fatal exceptions",
+          "type": "absent",
+          "patterns": ["Fatal Exception", "FATAL"],
+          "fail_action": "fail"
+        }
+      ]
+    }
+  ],
+
+  "report": {
+    "output_dir": ".af-e2e/reports/",
+    "format": "json"
+  }
+}

--- a/.af-smoke/rc-test-plan.json
+++ b/.af-smoke/rc-test-plan.json
@@ -1,0 +1,184 @@
+{
+  "_meta": {
+    "plan_id": "flutter-rc-smoke",
+    "plugin": "flutter",
+    "version": "1.0.0",
+    "description": "Post-publish smoke plan for the AppsFlyer Flutter plugin. Exercises SMOKE-001/002/003 against example_rc_smoke/, which pins appsflyer_sdk: =<X.Y.Z-rcN> from pub.dev. rc-smoke.yml templates the pinned version into example_rc_smoke/pubspec.yaml before building. This plan never depends on plugin source.",
+    "platforms": ["android", "ios"],
+    "schema_version": "1.0.0",
+    "tooling_contract_ref": "SMOKE-001, SMOKE-002, SMOKE-003"
+  },
+
+  "config": {
+    "android": {
+      "package_name": "com.appsflyer.appsflyersdkexample",
+      "activity": ".MainActivity",
+      "apk_path": "example_rc_smoke/build/app/outputs/flutter-apk/app-debug.apk",
+      "build_cmd": "cd example_rc_smoke && flutter pub get && flutter build apk --debug"
+    },
+    "ios": {
+      "bundle_id": "com.appsflyer.example",
+      "app_path": "example_rc_smoke/build/ios/iphonesimulator/Runner.app",
+      "build_cmd": "cd example_rc_smoke && flutter pub get && flutter build ios --simulator --debug"
+    }
+  },
+
+  "phases": [
+    {
+      "id": "phase_1",
+      "name": "Cold launch smoke (RC artifact)",
+      "scenario_ref": "SMOKE-001",
+      "description": "Fresh install using the pub.dev-pinned RC build. Validates SDK startup, install conversion data, pre/post-start API markers, three standard events, and HTTP 200 responses.",
+      "requires_fresh_install": true,
+      "wait_after_launch_sec": 25,
+      "checks": [
+        {
+          "id": "sdk_started",
+          "description": "startSDK returns SUCCESS",
+          "type": "log_contains",
+          "pattern": "[AF_QA][startSDK] result: SUCCESS",
+          "fail_action": "abort"
+        },
+        {
+          "id": "is_first_launch_true",
+          "description": "onInstallConversionData fires with is_first_launch=true",
+          "type": "log_contains",
+          "pattern": "[AF_QA][CALLBACK][onInstallConversionData]",
+          "payload_check": {"field": "is_first_launch", "expected": "true"},
+          "fail_action": "abort"
+        },
+        {
+          "id": "pre_start_apis_complete",
+          "description": "Pre-start auto APIs ran",
+          "type": "log_contains",
+          "pattern": "[AF_QA][AUTO_APIS] --- Pre-start auto APIs complete ---",
+          "fail_action": "fail"
+        },
+        {
+          "id": "post_start_apis_complete",
+          "description": "Post-start auto APIs ran",
+          "type": "log_contains",
+          "pattern": "[AF_QA][AUTO_APIS] --- Post-start auto APIs complete ---",
+          "fail_action": "fail"
+        },
+        {
+          "id": "event_af_demo_launch",
+          "description": "af_demo_launch event fires",
+          "type": "log_contains",
+          "pattern": "[AF_QA][logEvent(af_demo_launch)] result:",
+          "fail_action": "fail"
+        },
+        {
+          "id": "http_200_count",
+          "description": "At least 3 HTTP 200 responses from AppsFlyer servers",
+          "type": "count_matches",
+          "pattern": "response code:200 OK|response_status=200",
+          "minimum": 3,
+          "fail_action": "fail"
+        },
+        {
+          "id": "no_fatal_errors",
+          "description": "No fatal exceptions or SDK start errors",
+          "type": "absent",
+          "patterns": ["Fatal Exception", "FATAL", "[AF_QA][startSDK] error:", "response code:4", "response code:5"],
+          "fail_action": "fail"
+        }
+      ]
+    },
+
+    {
+      "id": "phase_2",
+      "name": "Background deep link (RC artifact)",
+      "scenario_ref": "SMOKE-002",
+      "description": "Backgrounds the RC build after Phase 1. Deep link returns app to foreground. onDeepLinking fires with Status.FOUND.",
+      "requires_fresh_install": false,
+      "wait_after_trigger_sec": 5,
+      "deep_link_url": "afexample://deeplink?deep_link_value=qa_deeplink_bg&af_sub1=background_test&pid=testmedia&c=deeplink_test",
+      "pre_actions": {
+        "android": ["adb shell input keyevent KEYCODE_HOME", "sleep 2"],
+        "ios": ["xcrun simctl launch {{UDID}} com.apple.mobilesafari", "sleep 2"]
+      },
+      "trigger": {
+        "android": "adb shell am start -a android.intent.action.VIEW -d \"{{DEEP_LINK_URL}}\"",
+        "ios": "xcrun simctl openurl {{UDID}} \"{{DEEP_LINK_URL}}\""
+      },
+      "checks": [
+        {
+          "id": "deeplink_found",
+          "description": "onDeepLinking fires with Status.FOUND",
+          "type": "log_contains",
+          "pattern": "status=Status.FOUND",
+          "fail_action": "fail"
+        },
+        {
+          "id": "deeplink_value_bg",
+          "description": "deepLinkValue matches qa_deeplink_bg",
+          "type": "log_contains",
+          "pattern": "deepLinkValue=qa_deeplink_bg",
+          "fail_action": "fail"
+        },
+        {
+          "id": "no_fatal_errors",
+          "description": "No fatal exceptions after deep link",
+          "type": "absent",
+          "patterns": ["Fatal Exception", "FATAL"],
+          "fail_action": "fail"
+        }
+      ]
+    },
+
+    {
+      "id": "phase_3",
+      "name": "Foreground deep link (RC artifact)",
+      "scenario_ref": "SMOKE-003",
+      "description": "Fresh install of the RC build. Brief launcher switch then deep link. onDeepLinking fires with Status.FOUND and deepLinkValue=qa_deeplink_fg.",
+      "requires_fresh_install": true,
+      "wait_after_launch_sec": 25,
+      "wait_after_trigger_sec": 5,
+      "deep_link_url": "afexample://deeplink?deep_link_value=qa_deeplink_fg&af_sub1=foreground_test&pid=testmedia&c=deeplink_test",
+      "pre_actions": {
+        "android": ["adb shell am start -a android.intent.action.MAIN -c android.intent.category.HOME", "sleep 1"],
+        "ios": ["xcrun simctl launch {{UDID}} com.apple.Preferences", "sleep 1"]
+      },
+      "trigger": {
+        "android": "adb shell am start -a android.intent.action.VIEW -d \"{{DEEP_LINK_URL}}\"",
+        "ios": "xcrun simctl openurl {{UDID}} \"{{DEEP_LINK_URL}}\""
+      },
+      "checks": [
+        {
+          "id": "sdk_started",
+          "description": "startSDK returns SUCCESS on fresh install",
+          "type": "log_contains",
+          "pattern": "[AF_QA][startSDK] result: SUCCESS",
+          "fail_action": "abort"
+        },
+        {
+          "id": "deeplink_found_fg",
+          "description": "onDeepLinking fires with Status.FOUND after foreground deep link",
+          "type": "log_contains",
+          "pattern": "status=Status.FOUND",
+          "fail_action": "fail"
+        },
+        {
+          "id": "deeplink_value_fg",
+          "description": "deepLinkValue matches qa_deeplink_fg",
+          "type": "log_contains",
+          "pattern": "deepLinkValue=qa_deeplink_fg",
+          "fail_action": "fail"
+        },
+        {
+          "id": "no_fatal_errors",
+          "description": "No fatal exceptions",
+          "type": "absent",
+          "patterns": ["Fatal Exception", "FATAL"],
+          "fail_action": "fail"
+        }
+      ]
+    }
+  ],
+
+  "report": {
+    "output_dir": ".af-smoke/reports/",
+    "format": "json"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ node_modules/
 covBadgeGen.js
 coverage/
 .env
+
+.af-e2e/reports/
+.af-smoke/reports/

--- a/.pubignore
+++ b/.pubignore
@@ -21,3 +21,9 @@ example/android/local.properties
 # CI/CD files
 .github/
 .travis.yml
+
+# RC pipeline scaffolding (never part of the pub.dev artifact)
+example_rc_smoke/
+.af-e2e/
+.af-smoke/
+scripts/

--- a/docs/rc-pipeline-poc.md
+++ b/docs/rc-pipeline-poc.md
@@ -1,0 +1,81 @@
+# RC pipeline POC
+
+This doc describes how to prove the unified RC pipeline works end-to-end before we trust it for a real release. Two levels: local simulation (no remote calls) and CI dry-run against a throwaway version.
+
+For the user-facing operator manual, see [`RELEASE_USER_MANUAL.md`](./RELEASE_USER_MANUAL.md) (added in PR D). For contract meaning and stage definitions, see [`appsflyer-mobile-plugin-tooling/contracts/rc-release-contract.md`](https://github.com/AppsFlyerSDK/appsflyer-mobile-plugin-tooling/blob/main/contracts/rc-release-contract.md).
+
+## Why a POC
+
+The pipeline is additive; it does not replace a working release process. We need a way to exercise every stage without risking a real pub.dev artifact. Two layers cover that.
+
+## Level 1: local simulation
+
+Run on your workstation. No remote calls. Proves the plans, runner, scripts, and example app scaffolding all line up.
+
+```sh
+./scripts/simulate-rc-pipeline.sh --platform ios
+# or --platform android
+# or --platform both
+```
+
+What the script does:
+
+1. Cuts a throwaway branch `releases/poc/99.99.99-rc1-poc`.
+2. Stamps `pubspec.yaml` with `99.99.99-rc1-poc` (the RC-PREP stage in the contract).
+3. Runs `.af-e2e/test-plan.json` against `example/` via `scripts/af-smoke-runner.sh` (the RC-E2E stage).
+4. Simulates RC-PUBLISH — nothing real happens here, it prints a confirmation.
+5. Runs `.af-smoke/rc-test-plan.json` against `example/` using a runtime-rewritten plan that substitutes `path: ..` for the pub.dev pin (the RC-SMOKE stage, minus the registry dependency).
+6. Restores `pubspec.yaml` and deletes the throwaway branch.
+
+Exit code 0 means both E2E and smoke passed. Exit code 1 means one of them failed; the script leaves a passing combined summary off.
+
+Pass `--keep-branch` if you want to inspect the staging state after the run.
+
+## Level 2: CI dry-run
+
+Once the four plugin PRs (A, B, C, D) land, exercise the full workflow tree against a scratch version. Inputs:
+
+- `flutter_version=99.99.99-rc1`
+- `ios_sdk_version=6.17.7` (or whatever today's native wrappers pin)
+- `android_sdk_version=6.17.4`
+- `dry_run=true`
+
+Expected behavior with `dry_run=true`:
+
+- `rc-release.yml` creates the branch, applies version bumps, runs CI, and runs the two E2E workflows via `workflow_call`.
+- `publish-rc` job runs validation but skips the real `flutter pub publish`.
+- `open-pr` opens the PR to `master`.
+- `create-prerelease` cuts the `99.99.99-rc1` tag as a GitHub prerelease.
+- `notify-team` posts a Slack ping (or logs a skip if the webhook is unreachable).
+- `rc-smoke.yml` fires via `workflow_run` on completion, detects the `dry_run=true` signal, posts `rc-smoke/pub.dev` check-run with conclusion `skipped`, and exits fast.
+
+Expected behavior with `dry_run=false` on the same scratch version (run after the dry run):
+
+- Everything above, plus `publish-rc` actually publishes `99.99.99-rc1` to pub.dev.
+- `rc-smoke.yml` templates `example_rc_smoke/pubspec.yaml` with `appsflyer_sdk: =99.99.99-rc1`, builds, runs `SMOKE-001/002/003` on both platforms, uploads reports, and posts `rc-smoke/pub.dev` with conclusion `success`.
+- The PR shows all four checks green: `CI`, `E2E — Full Integration Tests`, `E2E — Android Integration Tests`, `rc-smoke/pub.dev`.
+
+Negative promote test (proves the gate):
+
+1. Take an old merged PR or a fresh dummy PR without a green `rc-smoke/pub.dev` check.
+2. Apply the `pass QA ready for deploy` label.
+3. `promote-release.yml` should fail fast with a PR comment pointing at the missing check-run.
+
+Positive promote test (full loop):
+
+1. On the real `99.99.99-rc1` PR, apply the `pass QA ready for deploy` label.
+2. `promote-release.yml` verifies the green smoke check, strips `-rc1` from the release branch, pushes, and updates the PR description.
+3. Merge the PR manually.
+4. `production-release.yml` publishes `99.99.99` to pub.dev and cuts the GitHub release.
+5. Clean up: delete the `99.99.99-rc1` tag and the `99.99.99` tag from the scratch version so the version slot is free again.
+
+## POC acceptance checklist
+
+- [ ] `simulate-rc-pipeline.sh --platform both` exits zero on a dev workstation with an emulator + simulator booted.
+- [ ] Dry-run CI run on `99.99.99-rc1` produces a PR with `rc-smoke/pub.dev=skipped` and no pub.dev artifact.
+- [ ] Wet-run CI run on `99.99.99-rc1` produces a PR with `rc-smoke/pub.dev=success` and a real pub.dev artifact.
+- [ ] Negative promote (mis-applied label) leaves a PR comment and does not strip `-rc1`.
+- [ ] Positive promote strips `-rc1`, merge publishes `99.99.99` to pub.dev, GitHub release exists.
+- [ ] All four workflows (`rc-release.yml`, `rc-smoke.yml`, `promote-release.yml`, `production-release.yml`) appear in the Actions tab with the expected job names.
+
+Mark each of these as you go in the PR description of the PR that lands this doc; those are the acceptance criteria.

--- a/example_rc_smoke/README.md
+++ b/example_rc_smoke/README.md
@@ -1,0 +1,35 @@
+# example_rc_smoke/
+
+Smoke-test Flutter app that pins the published RC from pub.dev. Exists only to validate the RC artifact after `rc-release.yml` completes publishing.
+
+## What's committed here
+
+- `pubspec.yaml` — template. The `appsflyer_sdk: RC_VERSION_PLACEHOLDER` line is rewritten by `rc-smoke.yml` to pin the exact RC version (e.g. `appsflyer_sdk: =6.18.0-rc1`).
+- `README.md` — this file.
+
+That's it. The rest of the app (Android project, iOS project, lib/, assets, tests) is **not** committed here. `rc-smoke.yml` synthesizes it at CI time by rsyncing `example/` into this directory (excluding `pubspec.yaml`), so both app shells stay in lockstep without duplicating source.
+
+## Exclusion from the published package
+
+`example_rc_smoke/` is in `.pubignore`; it is never part of the plugin artifact uploaded to pub.dev.
+
+## Why not commit a full copy of example/?
+
+Two directories of identical app source drift quickly and bloat PR diffs. Everything that differs between `example/` and `example_rc_smoke/` lives in `pubspec.yaml`: the dependency shape. The rest is byte-for-byte the same app, built against a different `appsflyer_sdk` source.
+
+## Running this locally
+
+You normally won't. For a local dry-run of the full RC pipeline use:
+
+```sh
+./scripts/simulate-rc-pipeline.sh --platform ios
+```
+
+It rewrites the smoke plan at runtime to point at `example/` with a `path: ..` dependency, so you exercise the runner + plan shape without needing to publish anything to pub.dev.
+
+## Related files
+
+- `../scripts/af-smoke-runner.sh` — the runner `rc-smoke.yml` calls.
+- `../.af-smoke/rc-test-plan.json` — the test plan; `build_cmd` targets `example_rc_smoke/`.
+- `../.github/workflows/rc-smoke.yml` — the workflow that templates this `pubspec.yaml` and runs smoke.
+- `../docs/RELEASE_USER_MANUAL.md` — operator manual.

--- a/example_rc_smoke/pubspec.yaml
+++ b/example_rc_smoke/pubspec.yaml
@@ -1,0 +1,31 @@
+name: appsflyer_sdk_rc_smoke
+description: RC smoke test app for the AppsFlyer Flutter plugin. Pins the published RC version from pub.dev. CI workflow rc-smoke.yml templates the version string into this file before building.
+
+version: 1.0.0+1
+
+publish_to: none
+
+environment:
+  sdk: '>=2.12.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  # CI templates the exact pinned RC version here, e.g.:
+  #   appsflyer_sdk: =6.18.0-rc1
+  # Local runs via scripts/simulate-rc-pipeline.sh substitute path: ..
+  appsflyer_sdk: RC_VERSION_PLACEHOLDER
+
+  cupertino_icons: ^1.0.6
+  flutter_dotenv: ^5.1.0
+  path_provider: ^2.1.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^4.0.0
+
+flutter:
+  uses-material-design: true
+  assets:
+    - .env

--- a/scripts/af-smoke-runner.sh
+++ b/scripts/af-smoke-runner.sh
@@ -367,7 +367,7 @@ build_app() {
   log_step "Building app"
   log_info "Running: $BUILD_CMD"
   if ! $DRY_RUN; then
-    eval "$BUILD_CMD"
+    (eval "$BUILD_CMD")
   fi
 }
 

--- a/scripts/af-smoke-runner.sh
+++ b/scripts/af-smoke-runner.sh
@@ -1,0 +1,791 @@
+#!/usr/bin/env bash
+#
+# af-smoke-runner.sh — Unified AppsFlyer plugin smoke test runner
+#
+# Drives a full smoke test cycle for any AppsFlyer plugin using ADB (Android)
+# and xcrun simctl (iOS). Reads a JSON test plan, executes each phase, validates
+# log output against expected patterns, and produces a structured JSON report.
+#
+# Usage:
+#   ./af-smoke-runner.sh --platform android --plan .af-smoke/test-plan.json
+#   ./af-smoke-runner.sh --platform ios --plan .af-smoke/test-plan.json
+#   ./af-smoke-runner.sh --platform android --plan .af-smoke/test-plan.json --phase phase_1
+#   ./af-smoke-runner.sh --platform android --plan .af-smoke/test-plan.json --dry-run
+#   ./af-smoke-runner.sh --platform android --plan .af-smoke/test-plan.json --build
+#
+# Requirements:
+#   - bash 4+, jq
+#   - Android: ADB in PATH, emulator booted
+#   - iOS: Xcode CLI tools, simulator booted
+#
+# The script is agent-agnostic: any AI coding assistant (Cursor, Claude Code,
+# GitHub Copilot, Windsurf) or a human can invoke it from a terminal.
+
+set -euo pipefail
+
+# ─── Defaults ────────────────────────────────────────────────────────────────
+
+PLATFORM=""
+PLAN_FILE=""
+PHASE_FILTER=""
+DRY_RUN=false
+BUILD_FIRST=false
+VERBOSE=false
+REPORT_DIR=""
+LOG_TAG="AF_QA"
+
+# Timestamps
+RUN_ID=""
+RUN_START=""
+
+# Counters
+TOTAL_CHECKS=0
+PASSED_CHECKS=0
+FAILED_CHECKS=0
+WARNED_CHECKS=0
+ABORTED=false
+
+# ─── Colors ──────────────────────────────────────────────────────────────────
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ─── Usage ───────────────────────────────────────────────────────────────────
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Options:
+  --platform <android|ios>   Target platform (required)
+  --plan <path>              Path to test-plan.json (required)
+  --phase <phase_id>         Run only this phase (optional; runs all if omitted)
+  --build                    Build the app before running (optional)
+  --dry-run                  Show what would run without executing (optional)
+  --verbose                  Print extra debug output (optional)
+  --report-dir <path>        Override report output directory (optional)
+  -h, --help                 Show this help
+
+Examples:
+  $(basename "$0") --platform android --plan .af-smoke/test-plan.json
+  $(basename "$0") --platform ios --plan .af-smoke/test-plan.json --phase phase_1
+  $(basename "$0") --platform android --plan .af-smoke/test-plan.json --build --verbose
+EOF
+  exit 0
+}
+
+# ─── Logging helpers ─────────────────────────────────────────────────────────
+
+log_info()  { echo -e "${CYAN}[INFO]${NC}  $*"; }
+log_ok()    { echo -e "${GREEN}[PASS]${NC}  $*"; }
+log_fail()  { echo -e "${RED}[FAIL]${NC}  $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_step()  { echo -e "${BOLD}────── $* ──────${NC}"; }
+log_debug() { if $VERBOSE; then echo -e "[DEBUG] $*"; fi; }
+
+# ─── Argument parsing ────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --platform)  PLATFORM="$2"; shift 2 ;;
+    --plan)      PLAN_FILE="$2"; shift 2 ;;
+    --phase)     PHASE_FILTER="$2"; shift 2 ;;
+    --build)     BUILD_FIRST=true; shift ;;
+    --dry-run)   DRY_RUN=true; shift ;;
+    --verbose)   VERBOSE=true; shift ;;
+    --report-dir) REPORT_DIR="$2"; shift 2 ;;
+    -h|--help)   usage ;;
+    *) echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+[[ -z "$PLATFORM" ]] && { echo "Error: --platform is required"; usage; }
+[[ -z "$PLAN_FILE" ]] && { echo "Error: --plan is required"; usage; }
+[[ ! -f "$PLAN_FILE" ]] && { echo "Error: Plan file not found: $PLAN_FILE"; exit 1; }
+
+# Validate platform
+case "$PLATFORM" in
+  android|ios) ;;
+  *) echo "Error: --platform must be 'android' or 'ios'"; exit 1 ;;
+esac
+
+# Check dependencies
+command -v jq >/dev/null 2>&1 || { echo "Error: jq is required but not installed. Install with: brew install jq"; exit 1; }
+
+if [[ "$PLATFORM" == "android" ]]; then
+  command -v adb >/dev/null 2>&1 || { echo "Error: adb not found in PATH"; exit 1; }
+elif [[ "$PLATFORM" == "ios" ]]; then
+  command -v xcrun >/dev/null 2>&1 || { echo "Error: xcrun not found (install Xcode CLI tools)"; exit 1; }
+fi
+
+# ─── Read plan ───────────────────────────────────────────────────────────────
+
+PLAN=$(cat "$PLAN_FILE")
+PLAN_ID=$(echo "$PLAN" | jq -r '._meta.plan_id // "unknown"')
+PLUGIN_NAME=$(echo "$PLAN" | jq -r '._meta.plugin // "unknown"')
+
+# Platform-specific config
+PACKAGE_NAME=$(echo "$PLAN" | jq -r ".config.${PLATFORM}.package_name // .config.${PLATFORM}.bundle_id // \"\"")
+APP_PATH=$(echo "$PLAN" | jq -r ".config.${PLATFORM}.apk_path // .config.${PLATFORM}.app_path // \"\"")
+BUILD_CMD=$(echo "$PLAN" | jq -r ".config.${PLATFORM}.build_cmd // \"\"")
+ACTIVITY=$(echo "$PLAN" | jq -r ".config.${PLATFORM}.activity // \"\"")
+
+# Report directory
+if [[ -z "$REPORT_DIR" ]]; then
+  REPORT_DIR=$(echo "$PLAN" | jq -r '.report.output_dir // ".af-smoke/reports/"')
+fi
+
+# Generate run ID
+RUN_START=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+RUN_ID="${PLAN_ID}-${PLATFORM}-$(date +%Y%m%d_%H%M%S)"
+
+log_info "Plan: ${PLAN_ID} | Plugin: ${PLUGIN_NAME} | Platform: ${PLATFORM}"
+log_info "Package: ${PACKAGE_NAME}"
+log_info "Run ID: ${RUN_ID}"
+
+if $DRY_RUN; then
+  log_warn "DRY RUN MODE — no commands will be executed"
+fi
+
+# ─── Setup report directory ──────────────────────────────────────────────────
+
+mkdir -p "$REPORT_DIR"
+REPORT_FILE="${REPORT_DIR}/${RUN_ID}.json"
+PHASE_RESULTS="[]"
+
+# ─── Platform helpers ────────────────────────────────────────────────────────
+
+# --- Android ---
+
+android_get_device() {
+  adb devices | grep -w "device" | head -1 | awk '{print $1}'
+}
+
+android_is_installed() {
+  adb shell pm list packages 2>/dev/null | grep -q "$PACKAGE_NAME"
+}
+
+android_uninstall() {
+  log_info "Uninstalling $PACKAGE_NAME..."
+  if android_is_installed; then
+    adb uninstall "$PACKAGE_NAME" 2>/dev/null || true
+  else
+    log_info "App not installed, skipping uninstall"
+  fi
+}
+
+android_install() {
+  log_info "Installing $APP_PATH..."
+  if [[ ! -f "$APP_PATH" ]]; then
+    log_fail "APK not found at $APP_PATH"
+    if [[ -n "$BUILD_CMD" ]]; then
+      log_info "Hint: run with --build to build first, or manually: $BUILD_CMD"
+    fi
+    return 1
+  fi
+  adb install -r "$APP_PATH"
+}
+
+android_launch() {
+  log_info "Launching $PACKAGE_NAME..."
+  adb logcat -c
+  adb shell am start -n "${PACKAGE_NAME}/${ACTIVITY}" 2>/dev/null || \
+    adb shell monkey -p "$PACKAGE_NAME" -c android.intent.category.LAUNCHER 1 2>/dev/null
+}
+
+android_get_pid() {
+  adb shell pidof "$PACKAGE_NAME" 2>/dev/null | tr -d '[:space:]'
+}
+
+android_collect_logs() {
+  local log_file="$1"
+  local pid
+  pid=$(android_get_pid)
+  if [[ -n "$pid" ]]; then
+    log_debug "Collecting logs for PID $pid"
+    adb logcat -d 2>&1 | grep -E "${LOG_TAG}|AppsFlyer|response code:|preparing data:" > "$log_file" || true
+  else
+    log_warn "Could not find PID for $PACKAGE_NAME, collecting all AF logs"
+    adb logcat -d 2>&1 | grep -E "${LOG_TAG}|AppsFlyer|response code:|preparing data:" > "$log_file" || true
+  fi
+}
+
+android_background_app() {
+  log_info "Backgrounding app (HOME key)..."
+  adb shell input keyevent KEYCODE_HOME
+}
+
+android_trigger_deeplink() {
+  local url="$1"
+  log_info "Triggering deep link: $url"
+  adb shell am start -a android.intent.action.VIEW -d "$url" 2>/dev/null || true
+}
+
+android_is_alive() {
+  local pid
+  pid=$(android_get_pid)
+  [[ -n "$pid" ]]
+}
+
+# --- iOS ---
+
+IOS_UDID=""
+
+ios_get_booted_udid() {
+  xcrun simctl list devices booted -j 2>/dev/null | \
+    jq -r '[.devices[][] | select(.state == "Booted")] | first | .udid // empty'
+}
+
+ios_ensure_udid() {
+  if [[ -z "$IOS_UDID" ]]; then
+    IOS_UDID=$(ios_get_booted_udid)
+    if [[ -z "$IOS_UDID" ]]; then
+      log_fail "No booted iOS simulator found. Boot one with: xcrun simctl boot <UDID>"
+      exit 1
+    fi
+    log_info "Using simulator: $IOS_UDID"
+  fi
+}
+
+ios_is_installed() {
+  xcrun simctl listapps "$IOS_UDID" 2>/dev/null | grep -q "$PACKAGE_NAME" 2>/dev/null
+}
+
+ios_uninstall() {
+  ios_ensure_udid
+  log_info "Uninstalling $PACKAGE_NAME..."
+  if ios_is_installed; then
+    xcrun simctl uninstall "$IOS_UDID" "$PACKAGE_NAME" 2>/dev/null || true
+  else
+    log_info "App not installed, skipping uninstall"
+  fi
+}
+
+ios_install() {
+  ios_ensure_udid
+  log_info "Installing $APP_PATH..."
+  if [[ ! -d "$APP_PATH" ]]; then
+    log_fail "App bundle not found at $APP_PATH"
+    if [[ -n "$BUILD_CMD" ]]; then
+      log_info "Hint: run with --build to build first, or manually: $BUILD_CMD"
+    fi
+    return 1
+  fi
+  xcrun simctl install "$IOS_UDID" "$APP_PATH"
+}
+
+ios_launch() {
+  ios_ensure_udid
+  log_info "Launching $PACKAGE_NAME..."
+  xcrun simctl launch "$IOS_UDID" "$PACKAGE_NAME" 2>&1 || true
+}
+
+ios_get_pid() {
+  xcrun simctl spawn "$IOS_UDID" launchctl list 2>/dev/null | \
+    grep "$PACKAGE_NAME" | awk '{print $1}' | head -1
+}
+
+ios_collect_logs() {
+  local log_file="$1"
+
+  ios_ensure_udid
+
+  # Strategy 1: Read the app's af_qa_logs.txt from the simulator filesystem
+  local sim_data_dir
+  sim_data_dir="$HOME/Library/Developer/CoreSimulator/Devices/${IOS_UDID}/data"
+  local qa_log_found=false
+
+  if [[ -d "$sim_data_dir" ]]; then
+    local qa_log
+    qa_log=$(find "$sim_data_dir/Containers/Data/Application" -name "af_qa_logs.txt" -maxdepth 4 2>/dev/null | head -1)
+    if [[ -n "$qa_log" && -f "$qa_log" ]]; then
+      log_debug "Found iOS QA log file: $qa_log"
+      cp "$qa_log" "$log_file"
+      qa_log_found=true
+    fi
+  fi
+
+  # Strategy 2: Fall back to xcrun simctl log show
+  if ! $qa_log_found; then
+    log_debug "QA log file not found, falling back to simctl log show"
+    xcrun simctl spawn "$IOS_UDID" log show \
+      --last 120s --style compact 2>&1 | \
+      grep -E "${LOG_TAG}|appsflyer|CFNetwork:Summary|response_status" > "$log_file" || true
+  fi
+}
+
+ios_background_app() {
+  ios_ensure_udid
+  log_info "Backgrounding app (launching Safari)..."
+  xcrun simctl launch "$IOS_UDID" com.apple.mobilesafari 2>/dev/null || true
+}
+
+ios_trigger_deeplink() {
+  local url="$1"
+  ios_ensure_udid
+  log_info "Triggering deep link: $url"
+  xcrun simctl openurl "$IOS_UDID" "$url" 2>/dev/null || true
+}
+
+# ─── Platform dispatcher ────────────────────────────────────────────────────
+
+platform_uninstall() {
+  if [[ "$PLATFORM" == "android" ]]; then android_uninstall; else ios_uninstall; fi
+}
+
+platform_install() {
+  if [[ "$PLATFORM" == "android" ]]; then android_install; else ios_install; fi
+}
+
+platform_launch() {
+  if [[ "$PLATFORM" == "android" ]]; then android_launch; else ios_launch; fi
+}
+
+platform_collect_logs() {
+  if [[ "$PLATFORM" == "android" ]]; then android_collect_logs "$1"; else ios_collect_logs "$1"; fi
+}
+
+platform_background() {
+  if [[ "$PLATFORM" == "android" ]]; then android_background_app; else ios_background_app; fi
+}
+
+platform_trigger_deeplink() {
+  if [[ "$PLATFORM" == "android" ]]; then android_trigger_deeplink "$1"; else ios_trigger_deeplink "$1"; fi
+}
+
+# ─── Build ───────────────────────────────────────────────────────────────────
+
+build_app() {
+  if [[ -z "$BUILD_CMD" ]]; then
+    log_warn "No build_cmd configured in test plan for $PLATFORM"
+    return 1
+  fi
+  log_step "Building app"
+  log_info "Running: $BUILD_CMD"
+  if ! $DRY_RUN; then
+    eval "$BUILD_CMD"
+  fi
+}
+
+# ─── Log validation engine ───────────────────────────────────────────────────
+
+# validate_check <log_file> <check_json>
+# Returns a JSON object: {"status": "PASS|FAIL|WARN", "evidence": "..."}
+validate_check() {
+  local log_file="$1"
+  local check_json="$2"
+
+  local check_id check_type pattern description fail_action
+  check_id=$(echo "$check_json" | jq -r '.id')
+  check_type=$(echo "$check_json" | jq -r '.type')
+  description=$(echo "$check_json" | jq -r '.description')
+  fail_action=$(echo "$check_json" | jq -r '.fail_action // "fail"')
+
+  log_debug "Validating check: $check_id ($check_type)"
+
+  case "$check_type" in
+
+    log_contains)
+      pattern=$(echo "$check_json" | jq -r '.pattern')
+      local match
+      match=$(grep -F "$pattern" "$log_file" 2>/dev/null | head -1 || true)
+      if [[ -n "$match" ]]; then
+        # Optional payload_check
+        local payload_field payload_expected
+        payload_field=$(echo "$check_json" | jq -r '.payload_check.field // empty')
+        if [[ -n "$payload_field" ]]; then
+          payload_expected=$(echo "$check_json" | jq -r '.payload_check.expected')
+          if echo "$match" | grep -q "${payload_field}.*${payload_expected}" 2>/dev/null || \
+             echo "$match" | grep -q "\"${payload_field}\":.*${payload_expected}" 2>/dev/null || \
+             echo "$match" | grep -q "${payload_field}=${payload_expected}" 2>/dev/null || \
+             echo "$match" | grep -q "${payload_field}: ${payload_expected}" 2>/dev/null; then
+            echo "{\"status\":\"PASS\",\"evidence\":$(echo "$match" | head -c 500 | jq -Rs .)}"
+          else
+            echo "{\"status\":\"FAIL\",\"evidence\":\"Pattern found but payload check failed: ${payload_field} != ${payload_expected}. Line: $(echo "$match" | head -c 300 | jq -Rs .)\"}"
+          fi
+        else
+          echo "{\"status\":\"PASS\",\"evidence\":$(echo "$match" | head -c 500 | jq -Rs .)}"
+        fi
+      else
+        echo "{\"status\":\"FAIL\",\"evidence\":\"Pattern not found in logs: ${pattern}\"}"
+      fi
+      ;;
+
+    count_matches)
+      pattern=$(echo "$check_json" | jq -r '.pattern')
+      local minimum
+      minimum=$(echo "$check_json" | jq -r '.minimum // 1')
+      local count
+      count=$(grep -cE "$pattern" "$log_file" 2>/dev/null || echo "0")
+      if [[ "$count" -ge "$minimum" ]]; then
+        echo "{\"status\":\"PASS\",\"evidence\":\"Found ${count} matches (minimum: ${minimum})\"}"
+      else
+        echo "{\"status\":\"FAIL\",\"evidence\":\"Found only ${count} matches (minimum: ${minimum})\"}"
+      fi
+      ;;
+
+    absent)
+      local patterns_json patterns_arr status evidence
+      patterns_json=$(echo "$check_json" | jq -r '.patterns // []')
+      status="PASS"
+      evidence="No forbidden patterns found"
+      while IFS= read -r forbidden_pattern; do
+        forbidden_pattern=$(echo "$forbidden_pattern" | jq -r '.')
+        local found
+        found=$(grep -F "$forbidden_pattern" "$log_file" 2>/dev/null | head -1 || true)
+        if [[ -n "$found" ]]; then
+          status="FAIL"
+          evidence="Forbidden pattern found: ${forbidden_pattern} -> $(echo "$found" | head -c 200)"
+          break
+        fi
+      done < <(echo "$patterns_json" | jq -c '.[]')
+      echo "{\"status\":\"${status}\",\"evidence\":$(echo "$evidence" | jq -Rs .)}"
+      ;;
+
+    regex_match)
+      pattern=$(echo "$check_json" | jq -r '.pattern')
+      local match
+      match=$(grep -E "$pattern" "$log_file" 2>/dev/null | head -1 || true)
+      if [[ -n "$match" ]]; then
+        echo "{\"status\":\"PASS\",\"evidence\":$(echo "$match" | head -c 500 | jq -Rs .)}"
+      else
+        echo "{\"status\":\"FAIL\",\"evidence\":\"Regex not matched in logs: ${pattern}\"}"
+      fi
+      ;;
+
+    *)
+      echo "{\"status\":\"WARN\",\"evidence\":\"Unknown check type: ${check_type}\"}"
+      ;;
+  esac
+}
+
+# ─── Phase execution ─────────────────────────────────────────────────────────
+
+# run_phase <phase_json>
+run_phase() {
+  local phase_json="$1"
+
+  local phase_id phase_name requires_fresh scenario_ref wait_sec
+  phase_id=$(echo "$phase_json" | jq -r '.id')
+  phase_name=$(echo "$phase_json" | jq -r '.name')
+  requires_fresh=$(echo "$phase_json" | jq -r '.requires_fresh_install // false')
+  scenario_ref=$(echo "$phase_json" | jq -r '.scenario_ref // "N/A"')
+  wait_sec=$(echo "$phase_json" | jq -r '.wait_after_launch_sec // 25')
+  local wait_trigger_sec
+  wait_trigger_sec=$(echo "$phase_json" | jq -r '.wait_after_trigger_sec // 5')
+
+  log_step "Phase: ${phase_name} [${phase_id}] (Scenario: ${scenario_ref})"
+
+  local phase_log_file="${REPORT_DIR}/${RUN_ID}_${phase_id}_logs.txt"
+  local phase_status="PASS"
+  local checks_json="{}"
+
+  if $DRY_RUN; then
+    log_info "[DRY RUN] Would execute phase: $phase_name"
+    if [[ "$requires_fresh" == "true" ]]; then
+      log_info "[DRY RUN] Would uninstall + reinstall $PACKAGE_NAME"
+    fi
+    log_info "[DRY RUN] Would launch app and wait ${wait_sec}s"
+    log_info "[DRY RUN] Would collect logs and validate $(echo "$phase_json" | jq '.checks | length') checks"
+
+    # Produce a dry-run result
+    local dry_result
+    dry_result=$(jq -n \
+      --arg pid "$phase_id" \
+      --arg ps "DRY_RUN" \
+      '{phase_id: $pid, status: $ps, checks: {}, log_file: "N/A"}')
+    PHASE_RESULTS=$(echo "$PHASE_RESULTS" | jq --argjson r "$dry_result" '. + [$r]')
+    return
+  fi
+
+  # Fresh install if required
+  if [[ "$requires_fresh" == "true" ]]; then
+    platform_uninstall
+    sleep 1
+    if ! platform_install; then
+      log_fail "Installation failed — aborting phase"
+      phase_status="BLOCKED"
+      local blocked_result
+      blocked_result=$(jq -n \
+        --arg pid "$phase_id" \
+        --arg ps "$phase_status" \
+        '{phase_id: $pid, status: $ps, checks: {}, log_file: "N/A", note: "Installation failed"}')
+      PHASE_RESULTS=$(echo "$PHASE_RESULTS" | jq --argjson r "$blocked_result" '. + [$r]')
+      return
+    fi
+    sleep 1
+
+    platform_launch
+    log_info "Waiting ${wait_sec}s for SDK to settle..."
+    sleep "$wait_sec"
+  fi
+
+  # Pre-actions (deep link phases: background the app, etc.)
+  local pre_actions
+  pre_actions=$(echo "$phase_json" | jq -r ".pre_actions.${PLATFORM} // empty")
+  if [[ -n "$pre_actions" && "$pre_actions" != "null" ]]; then
+    log_info "Executing pre-actions..."
+    while IFS= read -r action; do
+      action=$(echo "$action" | jq -r '.')
+      # Replace {{UDID}} placeholder for iOS
+      if [[ "$PLATFORM" == "ios" ]]; then
+        ios_ensure_udid
+        action="${action//\{\{UDID\}\}/$IOS_UDID}"
+      fi
+      log_debug "Pre-action: $action"
+      eval "$action" 2>/dev/null || true
+    done < <(echo "$phase_json" | jq -c ".pre_actions.${PLATFORM}[]")
+  fi
+
+  # Trigger deep link if present
+  local deep_link_url
+  deep_link_url=$(echo "$phase_json" | jq -r '.deep_link_url // empty')
+  if [[ -n "$deep_link_url" ]]; then
+    # Use platform-specific trigger command or generic
+    local trigger_cmd
+    trigger_cmd=$(echo "$phase_json" | jq -r ".trigger.${PLATFORM} // empty")
+    if [[ -n "$trigger_cmd" && "$trigger_cmd" != "null" ]]; then
+      trigger_cmd="${trigger_cmd//\{\{DEEP_LINK_URL\}\}/$deep_link_url}"
+      if [[ "$PLATFORM" == "ios" ]]; then
+        ios_ensure_udid
+        trigger_cmd="${trigger_cmd//\{\{UDID\}\}/$IOS_UDID}"
+      fi
+      log_debug "Trigger command: $trigger_cmd"
+      eval "$trigger_cmd" 2>/dev/null || true
+    else
+      platform_trigger_deeplink "$deep_link_url"
+    fi
+    log_info "Waiting ${wait_trigger_sec}s for deep link to propagate..."
+    sleep "$wait_trigger_sec"
+  fi
+
+  # Collect logs
+  log_info "Collecting logs..."
+  platform_collect_logs "$phase_log_file"
+
+  local log_lines
+  log_lines=$(wc -l < "$phase_log_file" 2>/dev/null | tr -d ' ')
+  log_info "Collected ${log_lines} log lines"
+
+  if [[ "$log_lines" -eq 0 ]]; then
+    log_warn "No logs collected — check that the app is running and logging with [AF_QA]"
+  fi
+
+  # Validate each check
+  local num_checks
+  num_checks=$(echo "$phase_json" | jq '.checks | length')
+  log_info "Running ${num_checks} checks..."
+
+  local i=0
+  while [[ $i -lt $num_checks ]]; do
+    local check
+    check=$(echo "$phase_json" | jq -c ".checks[$i]")
+    local check_id
+    check_id=$(echo "$check" | jq -r '.id')
+    local check_desc
+    check_desc=$(echo "$check" | jq -r '.description')
+    local fail_action
+    fail_action=$(echo "$check" | jq -r '.fail_action // "fail"')
+
+    local result
+    result=$(validate_check "$phase_log_file" "$check")
+    local check_status
+    check_status=$(echo "$result" | jq -r '.status')
+    local evidence
+    evidence=$(echo "$result" | jq -r '.evidence')
+
+    TOTAL_CHECKS=$((TOTAL_CHECKS + 1))
+
+    if [[ "$check_status" == "PASS" ]]; then
+      log_ok "$check_id: $check_desc"
+      PASSED_CHECKS=$((PASSED_CHECKS + 1))
+    elif [[ "$check_status" == "WARN" ]]; then
+      log_warn "$check_id: $check_desc — $evidence"
+      WARNED_CHECKS=$((WARNED_CHECKS + 1))
+    else
+      log_fail "$check_id: $check_desc — $evidence"
+      FAILED_CHECKS=$((FAILED_CHECKS + 1))
+      phase_status="FAIL"
+
+      if [[ "$fail_action" == "abort" ]]; then
+        log_fail "Abort triggered by $check_id — skipping remaining checks in this phase"
+        ABORTED=true
+        break
+      fi
+    fi
+
+    checks_json=$(echo "$checks_json" | jq --arg k "$check_id" --argjson v "$result" '. + {($k): $v}')
+    i=$((i + 1))
+  done
+
+  # Produce phase result
+  local phase_result
+  phase_result=$(jq -n \
+    --arg pid "$phase_id" \
+    --arg ps "$phase_status" \
+    --argjson ch "$checks_json" \
+    --arg lf "$phase_log_file" \
+    '{phase_id: $pid, status: $ps, checks: $ch, log_file: $lf}')
+  PHASE_RESULTS=$(echo "$PHASE_RESULTS" | jq --argjson r "$phase_result" '. + [$r]')
+
+  echo ""
+}
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+
+main() {
+  log_step "AppsFlyer Smoke Runner"
+  log_info "Started at $RUN_START"
+
+  # Verify device/simulator is available (skip in dry-run)
+  if $DRY_RUN; then
+    if [[ "$PLATFORM" == "android" ]]; then
+      local device
+      device=$(android_get_device 2>/dev/null || true)
+      log_info "Android device: ${device:-<none — dry run>}"
+    else
+      IOS_UDID=$(ios_get_booted_udid 2>/dev/null || true)
+      log_info "iOS simulator: ${IOS_UDID:-<none — dry run>}"
+    fi
+  else
+    if [[ "$PLATFORM" == "android" ]]; then
+      local device
+      device=$(android_get_device)
+      if [[ -z "$device" ]]; then
+        log_fail "No Android device/emulator found. Start one with: emulator -avd <name>"
+        exit 1
+      fi
+      log_info "Android device: $device"
+    elif [[ "$PLATFORM" == "ios" ]]; then
+      ios_ensure_udid
+    fi
+  fi
+
+  # Build if requested
+  if $BUILD_FIRST; then
+    build_app
+  fi
+
+  # Get phases from the plan
+  local num_phases
+  num_phases=$(echo "$PLAN" | jq '.phases | length')
+  log_info "Test plan has ${num_phases} phases"
+
+  local p=0
+  while [[ $p -lt $num_phases ]]; do
+    local phase
+    phase=$(echo "$PLAN" | jq -c ".phases[$p]")
+    local pid
+    pid=$(echo "$phase" | jq -r '.id')
+
+    # Apply phase filter if set
+    if [[ -n "$PHASE_FILTER" && "$pid" != "$PHASE_FILTER" ]]; then
+      log_debug "Skipping phase $pid (filter: $PHASE_FILTER)"
+      p=$((p + 1))
+      continue
+    fi
+
+    run_phase "$phase"
+
+    if $ABORTED; then
+      log_warn "Run aborted after phase $pid"
+      break
+    fi
+
+    p=$((p + 1))
+  done
+
+  # ── Final report ──────────────────────────────────────────────────────────
+
+  local overall_status="PASS"
+  if [[ $FAILED_CHECKS -gt 0 ]]; then
+    overall_status="FAIL"
+  fi
+  if $ABORTED; then
+    overall_status="ABORTED"
+  fi
+
+  local run_end
+  run_end=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  local start_epoch end_epoch duration_sec
+  start_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$RUN_START" +%s 2>/dev/null || date -d "$RUN_START" +%s 2>/dev/null || echo "0")
+  end_epoch=$(date +%s)
+  duration_sec=$(( end_epoch - start_epoch ))
+
+  local device_name=""
+  if [[ "$PLATFORM" == "android" ]]; then
+    device_name=$(android_get_device 2>/dev/null || echo "N/A")
+  else
+    device_name="${IOS_UDID:-N/A}"
+  fi
+
+  local report
+  report=$(jq -n \
+    --arg rid "$RUN_ID" \
+    --arg plat "$PLATFORM" \
+    --arg dev "$device_name" \
+    --arg plan "$PLAN_ID" \
+    --arg plugin "$PLUGIN_NAME" \
+    --arg status "$overall_status" \
+    --arg start "$RUN_START" \
+    --arg end "$run_end" \
+    --argjson dur "$duration_sec" \
+    --argjson total "$TOTAL_CHECKS" \
+    --argjson passed "$PASSED_CHECKS" \
+    --argjson failed "$FAILED_CHECKS" \
+    --argjson warned "$WARNED_CHECKS" \
+    --argjson phases "$PHASE_RESULTS" \
+    '{
+      run_id: $rid,
+      platform: $plat,
+      device: $dev,
+      plan_id: $plan,
+      plugin: $plugin,
+      overall_status: $status,
+      started_at: $start,
+      finished_at: $end,
+      duration_sec: $dur,
+      total_checks: $total,
+      passed: $passed,
+      failed: $failed,
+      warned: $warned,
+      phases: $phases
+    }')
+
+  # Write report
+  if ! $DRY_RUN; then
+    echo "$report" | jq '.' > "$REPORT_FILE"
+    # Also write a latest.json symlink
+    ln -sf "$(basename "$REPORT_FILE")" "${REPORT_DIR}/latest.json"
+    log_info "Report saved to: $REPORT_FILE"
+  fi
+
+  # Print summary
+  echo ""
+  log_step "Summary"
+  echo -e "  Plan:     ${PLAN_ID}"
+  echo -e "  Plugin:   ${PLUGIN_NAME}"
+  echo -e "  Platform: ${PLATFORM}"
+  echo -e "  Device:   ${device_name}"
+  echo -e "  Checks:   ${PASSED_CHECKS}/${TOTAL_CHECKS} passed, ${FAILED_CHECKS} failed, ${WARNED_CHECKS} warned"
+
+  if [[ "$overall_status" == "PASS" ]]; then
+    echo -e "  Status:   ${GREEN}${BOLD}PASS${NC}"
+  elif [[ "$overall_status" == "ABORTED" ]]; then
+    echo -e "  Status:   ${RED}${BOLD}ABORTED${NC}"
+  else
+    echo -e "  Status:   ${RED}${BOLD}FAIL${NC}"
+  fi
+  echo ""
+
+  # Exit with appropriate code
+  if [[ "$overall_status" != "PASS" ]]; then
+    exit 1
+  fi
+}
+
+main

--- a/scripts/simulate-rc-pipeline.sh
+++ b/scripts/simulate-rc-pipeline.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+#
+# simulate-rc-pipeline.sh — Local dry-run of the RC pipeline end-to-end
+# -----------------------------------------------------------------------------
+# Exercises the same stages the CI pipeline runs (see
+# appsflyer-mobile-plugin-tooling/contracts/rc-release-contract.md), minus the
+# real pub.dev publish and the GitHub Actions environment.
+#
+#   1. Cut a throwaway release branch (releases/99.99.99-rc1-poc).
+#   2. Apply the version bumps that rc-release.yml would apply.
+#   3. Run the E2E test plan (.af-e2e/test-plan.json) against example/ via
+#      scripts/af-smoke-runner.sh.
+#   4. Run the smoke test plan (.af-smoke/rc-test-plan.json) against example/,
+#      simulating the pub.dev pin with a local path: .. dependency.
+#   5. Emit a combined PASS/FAIL summary and reset local state.
+#
+# Use this to prove the flow end-to-end on your workstation without burning
+# CI minutes or publishing anything. It never touches the remote.
+#
+# Usage:
+#   ./scripts/simulate-rc-pipeline.sh [--platform ios|android|both] [--keep-branch]
+#
+# Requirements:
+#   - git, flutter, jq
+#   - an Android emulator booted (for --platform android|both)
+#   - an iOS simulator booted (for --platform ios|both, macOS only)
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+
+PLATFORM="both"
+KEEP_BRANCH="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --platform)
+      PLATFORM="$2"; shift 2
+      ;;
+    --platform=*)
+      PLATFORM="${1#*=}"; shift
+      ;;
+    --keep-branch)
+      KEEP_BRANCH="true"; shift
+      ;;
+    -h|--help)
+      sed -n '2,30p' "$0"; exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2; exit 2
+      ;;
+  esac
+done
+
+case "$PLATFORM" in
+  ios|android|both) ;;
+  *) echo "Invalid --platform: $PLATFORM (ios|android|both)" >&2; exit 2 ;;
+esac
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+POC_VERSION="99.99.99-rc1-poc"
+POC_BRANCH="releases/poc/99.99.99-rc1-poc"
+ORIGINAL_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+cleanup() {
+  local rc=$?
+  if [[ "$KEEP_BRANCH" == "false" ]]; then
+    echo "▶ Cleanup: restoring $ORIGINAL_BRANCH"
+    git checkout --quiet "$ORIGINAL_BRANCH" 2>/dev/null || true
+    git branch -D "$POC_BRANCH" 2>/dev/null || true
+  else
+    echo "▶ Cleanup skipped (--keep-branch); branch $POC_BRANCH retained"
+  fi
+  exit $rc
+}
+trap cleanup EXIT INT TERM
+
+log() { printf "\n\033[1;36m▶ %s\033[0m\n" "$*"; }
+ok()  { printf "\033[1;32m✓ %s\033[0m\n" "$*"; }
+err() { printf "\033[1;31m✗ %s\033[0m\n" "$*"; }
+
+# ---------------------------------------------------------------------------
+# Stage 1: RC-PREP (local simulation)
+# ---------------------------------------------------------------------------
+log "Stage 1: RC-PREP — create throwaway branch and apply version bumps"
+if git show-ref --verify --quiet "refs/heads/$POC_BRANCH"; then
+  git branch -D "$POC_BRANCH" >/dev/null
+fi
+git checkout -b "$POC_BRANCH" >/dev/null
+ok "Branch created: $POC_BRANCH"
+
+PUBSPEC_BACKUP="$(mktemp)"
+cp pubspec.yaml "$PUBSPEC_BACKUP"
+sed -i.bak "s/^version: .*/version: $POC_VERSION/" pubspec.yaml
+rm -f pubspec.yaml.bak
+ok "pubspec.yaml version set to $POC_VERSION"
+
+# ---------------------------------------------------------------------------
+# Stage 2: RC-E2E (local simulation via example/)
+# ---------------------------------------------------------------------------
+log "Stage 2: RC-E2E — run .af-e2e/test-plan.json against example/"
+if [[ ! -f .af-e2e/test-plan.json ]]; then
+  err ".af-e2e/test-plan.json not found"; exit 1
+fi
+
+E2E_OK="true"
+if [[ "$PLATFORM" == "ios" || "$PLATFORM" == "both" ]]; then
+  if scripts/af-smoke-runner.sh --platform ios --plan .af-e2e/test-plan.json --build; then
+    ok "RC-E2E iOS: PASS"
+  else
+    err "RC-E2E iOS: FAIL"
+    E2E_OK="false"
+  fi
+fi
+if [[ "$PLATFORM" == "android" || "$PLATFORM" == "both" ]]; then
+  if scripts/af-smoke-runner.sh --platform android --plan .af-e2e/test-plan.json --build; then
+    ok "RC-E2E Android: PASS"
+  else
+    err "RC-E2E Android: FAIL"
+    E2E_OK="false"
+  fi
+fi
+
+if [[ "$E2E_OK" != "true" ]]; then
+  err "Aborting: RC-E2E failed. Post-publish smoke would not run in real pipeline."
+  mv "$PUBSPEC_BACKUP" pubspec.yaml
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Stage 3: RC-PUBLISH (skipped locally, simulated)
+# ---------------------------------------------------------------------------
+log "Stage 3: RC-PUBLISH — skipped locally (real pipeline publishes to pub.dev)"
+ok "Simulated publish of appsflyer_sdk@$POC_VERSION"
+
+# ---------------------------------------------------------------------------
+# Stage 4: RC-SMOKE (local simulation using example/ with path: ..)
+# ---------------------------------------------------------------------------
+log "Stage 4: RC-SMOKE — run .af-smoke/rc-test-plan.json (using example/ via path: ..)"
+
+SMOKE_PLAN_TMP="$(mktemp -d)/rc-test-plan.local.json"
+jq '(.config.android.build_cmd) = "cd example && flutter pub get && flutter build apk --debug"
+  | (.config.ios.build_cmd) = "cd example && flutter pub get && flutter build ios --simulator --debug"
+  | (.config.android.apk_path) = "example/build/app/outputs/flutter-apk/app-debug.apk"
+  | (.config.ios.app_path) = "example/build/ios/iphonesimulator/Runner.app"
+  | (._meta.description) += " [LOCAL SIMULATION: example/ substituted for example_rc_smoke/]"' \
+  .af-smoke/rc-test-plan.json > "$SMOKE_PLAN_TMP"
+
+SMOKE_OK="true"
+if [[ "$PLATFORM" == "ios" || "$PLATFORM" == "both" ]]; then
+  if scripts/af-smoke-runner.sh --platform ios --plan "$SMOKE_PLAN_TMP" --build; then
+    ok "RC-SMOKE iOS: PASS"
+  else
+    err "RC-SMOKE iOS: FAIL"
+    SMOKE_OK="false"
+  fi
+fi
+if [[ "$PLATFORM" == "android" || "$PLATFORM" == "both" ]]; then
+  if scripts/af-smoke-runner.sh --platform android --plan "$SMOKE_PLAN_TMP" --build; then
+    ok "RC-SMOKE Android: PASS"
+  else
+    err "RC-SMOKE Android: FAIL"
+    SMOKE_OK="false"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+log "Summary"
+echo "Branch:   $POC_BRANCH (throwaway)"
+echo "Version:  $POC_VERSION"
+echo "Platform: $PLATFORM"
+if [[ "$E2E_OK" == "true" && "$SMOKE_OK" == "true" ]]; then
+  ok "All simulated RC stages PASS"
+  mv "$PUBSPEC_BACKUP" pubspec.yaml
+  exit 0
+else
+  err "Simulated RC failed — see output above"
+  mv "$PUBSPEC_BACKUP" pubspec.yaml
+  exit 1
+fi


### PR DESCRIPTION
## Summary

First of four sibling PRs implementing the unified RC release pipeline ([plan](../blob/master/docs/rc-pipeline-poc.md)). PR A lands the file-layout pieces B, C, and D depend on.

- **`.af-e2e/test-plan.json`** — thorough 3-phase plan for pre-publish E2E against plugin source via `example/`. Scenario refs `E2E-001/002/003`.
- **`.af-smoke/rc-test-plan.json`** — minimal 3-phase plan for post-publish smoke against `example_rc_smoke/` (pub.dev RC pin). Scenario refs `SMOKE-001/002/003`.
- **`scripts/af-smoke-runner.sh`** — pinned snapshot of the tooling runner at its final path.
- **`scripts/simulate-rc-pipeline.sh`** — local dry-run of the full RC flow. No remote calls; uses `example/` with a runtime-rewritten plan that substitutes `path: ..` for the pub.dev pin.
- **`example_rc_smoke/pubspec.yaml`** + `README.md` — template with `RC_VERSION_PLACEHOLDER`. `rc-smoke.yml` (PR C) rsyncs `example/` into this directory at runtime (excluding pubspec.yaml) and templates the version string.
- **`docs/rc-pipeline-poc.md`** — acceptance test plan (local simulation + CI dry-run + negative promote gate test).
- **`.pubignore`** — exclude `example_rc_smoke/`, `.af-e2e/`, `.af-smoke/`, `scripts/` from the pub.dev artifact.

The three POC-era files are preserved on branch `wip/local-smoke-prototype`; this PR re-introduces the still-relevant content in its final homes.

## Companion PRs (stacked, merge in order)

1. **PR A (this one)**
2. PR B — wire `e2e.yml` + `e2e-android.yml` into `rc-release.yml`, remove `deploy_to_qa`.
3. PR C — add `rc-smoke.yml`, gate `promote-release.yml` on the `rc-smoke/pub.dev` check-run.
4. PR D — add `docs/RELEASE_USER_MANUAL.md` and thin skill pointers.

Depends on `appsflyer-mobile-plugin-tooling#1` for the new E2E contract and the widened `smoke-test-plan.schema.json` (one schema validates both plan families).

## Test plan

- [x] `bash -n scripts/af-smoke-runner.sh scripts/simulate-rc-pipeline.sh` — shell syntax (done locally).
- [x] Validate `.af-e2e/test-plan.json` and `.af-smoke/rc-test-plan.json` against the tooling schema.
- [x] Dry-run: `./scripts/simulate-rc-pipeline.sh --platform ios` on a workstation with a simulator booted.
- [x] Confirm `.pubignore` keeps `example_rc_smoke/` out of `flutter pub publish --dry-run`.

Made with [Cursor](https://cursor.com)