### PR TITLE
dev/fix-deeplink-on-foreground: Fix deeplink when app is in foreground

### DIFF
--- a/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
+++ b/android/src/main/java/com/appsflyer/appsflyersdk/AppsflyerSdkPlugin.java
@@ -92,7 +92,14 @@ public class AppsflyerSdkPlugin implements MethodCallHandler, FlutterPlugin, Act
     PluginRegistry.NewIntentListener onNewIntentListener = new PluginRegistry.NewIntentListener() {
         @Override
         public boolean onNewIntent(Intent intent) {
-            activity.setIntent(intent);
+            if (activity != null) {
+                activity.setIntent(intent);
+            }
+            if (mApplication != null) {
+                AppsFlyerLib.getInstance().performOnDeepLinking(intent, mApplication);
+            } else {
+                Log.d(AF_PLUGIN_TAG, "onNewIntent: application is null, skipping performOnDeepLinking");
+            }
             return false;
         }
     };


### PR DESCRIPTION
## Problem
When a push notification containing a OneLink URL is tapped while the app 
is in the foreground, the deeplink callback is never triggered. The callback 
only fires after the user backgrounds and foregrounds the app.

## Root Cause
`performOnDeepLinking()` was not being called inside `onNewIntentListener`. 
Android delivers the new intent via `onNewIntent()` for foreground apps, 
but the plugin was not forwarding this intent to the AppsFlyer SDK.

## Fix
Call `AppsFlyerLib.getInstance().performOnDeepLinking(intent, mApplication)` 
inside the `onNewIntentListener` callback so foreground deeplinks are 
processed immediately when the intent arrives.

## Testing
- App in foreground → tap push notification with OneLink → deeplink 
  callback fires immediately ✅
- App in background → tap push notification with OneLink → existing 
  behavior unchanged ✅