### PR TITLE
DELIVERY-115706: instrument example app for E2E + sync test plan to 6 phases

### DIFF
--- a/.af-e2e/test-plan.json
+++ b/.af-e2e/test-plan.json
@@ -3,10 +3,10 @@
     "plan_id": "flutter-e2e",
     "plugin": "flutter",
     "version": "1.0.0",
-    "description": "Thorough end-to-end test plan for the AppsFlyer Flutter plugin. Runs against plugin source (appsflyer_sdk: path: ..) in example/. Covers cold launch coverage, background deep link, and foreground deep link. Mapped to E2E-001, E2E-002, E2E-003 in appsflyer-mobile-plugin-tooling/contracts/e2e-test-contract.md.",
+    "description": "Thorough end-to-end test plan for the AppsFlyer Flutter plugin. Runs against plugin source (appsflyer_sdk: path: ..) in example/. Covers six scenarios: cold launch, background deep link, foreground deep link, custom event with parameters, identity APIs round-trip, and consent / SDK stop toggle. Mapped to E2E-001..E2E-006 in appsflyer-mobile-plugin-tooling/contracts/e2e-test-contract.md.",
     "platforms": ["android", "ios"],
     "schema_version": "1.0.0",
-    "tooling_contract_ref": "E2E-001, E2E-002, E2E-003"
+    "tooling_contract_ref": "E2E-001, E2E-002, E2E-003, E2E-004, E2E-005, E2E-006"
   },
 
   "config": {
@@ -212,6 +212,175 @@
         {
           "id": "no_fatal_errors",
           "description": "No fatal exceptions",
+          "type": "absent",
+          "patterns": ["Fatal Exception", "FATAL"],
+          "fail_action": "fail"
+        }
+      ]
+    },
+
+    {
+      "id": "phase_4",
+      "name": "Custom in-app event with parameters",
+      "scenario_ref": "E2E-004",
+      "description": "Verifies the custom logEvent with multi-type parameters (string, number, nested map) fired by the example app's auto-run after cold launch. Covers E2E-004.",
+      "requires_fresh_install": false,
+      "wait_after_trigger_sec": 5,
+      "checks": [
+        {
+          "id": "custom_event_logged",
+          "description": "logEvent invocation with name and full param map is logged",
+          "type": "log_contains",
+          "pattern": "[AF_QA][logEvent] name=af_qa_custom_purchase",
+          "fail_action": "fail"
+        },
+        {
+          "id": "param_revenue_present",
+          "description": "Revenue parameter present in serialized payload",
+          "type": "log_contains",
+          "pattern": "af_revenue",
+          "fail_action": "fail"
+        },
+        {
+          "id": "param_currency_present",
+          "description": "Currency parameter present",
+          "type": "log_contains",
+          "pattern": "af_currency",
+          "fail_action": "fail"
+        },
+        {
+          "id": "param_nested_metadata",
+          "description": "Nested metadata map preserved in payload",
+          "type": "log_contains",
+          "pattern": "metadata",
+          "fail_action": "fail"
+        },
+        {
+          "id": "custom_event_http_200",
+          "description": "Custom event request returns HTTP 200",
+          "type": "count_matches",
+          "pattern": "response code:200 OK|response_status=200",
+          "minimum": 1,
+          "fail_action": "fail"
+        },
+        {
+          "id": "no_log_event_error",
+          "description": "No logEvent error reported",
+          "type": "absent",
+          "patterns": ["[AF_QA][logEvent] error:"],
+          "fail_action": "fail"
+        }
+      ]
+    },
+
+    {
+      "id": "phase_5",
+      "name": "Identity APIs round-trip",
+      "scenario_ref": "E2E-005",
+      "description": "Sets customer user id, currency code, and additional data before start. Verifies readback and propagation into a post-start event payload. Covers E2E-005.",
+      "requires_fresh_install": true,
+      "wait_after_launch_sec": 25,
+      "wait_after_trigger_sec": 5,
+      "pre_start_apis": {
+        "set_customer_user_id": "e2e_user_42",
+        "set_currency_code": "EUR",
+        "set_additional_data": {"tenant": "qa_eu", "experiment": "rc_pipeline_v1"}
+      },
+      "checks": [
+        {
+          "id": "set_customer_user_id_logged",
+          "description": "setCustomerUserId readback present",
+          "type": "log_contains",
+          "pattern": "[AF_QA][setCustomerUserId] result: e2e_user_42",
+          "fail_action": "fail"
+        },
+        {
+          "id": "set_currency_code_logged",
+          "description": "setCurrencyCode readback present",
+          "type": "log_contains",
+          "pattern": "[AF_QA][setCurrencyCode] result: EUR",
+          "fail_action": "fail"
+        },
+        {
+          "id": "set_additional_data_logged",
+          "description": "setAdditionalData echoes its keys",
+          "type": "log_contains",
+          "pattern": "[AF_QA][setAdditionalData]",
+          "fail_action": "fail"
+        },
+        {
+          "id": "user_id_in_payload",
+          "description": "Post-start event payload carries customer_user_id",
+          "type": "log_contains",
+          "pattern": "customer_user_id=e2e_user_42",
+          "fail_action": "fail"
+        },
+        {
+          "id": "additional_data_in_payload",
+          "description": "Post-start event payload contains additional data tenant key",
+          "type": "log_contains",
+          "pattern": "tenant",
+          "fail_action": "fail"
+        },
+        {
+          "id": "is_first_launch_true",
+          "description": "Install conversion still fires with is_first_launch=true",
+          "type": "log_contains",
+          "pattern": "[AF_QA][CALLBACK][onInstallConversionData]",
+          "payload_check": {"field": "is_first_launch", "expected": "true"},
+          "fail_action": "fail"
+        },
+        {
+          "id": "identity_event_http_200",
+          "description": "Identity check event receives HTTP 200",
+          "type": "count_matches",
+          "pattern": "response code:200 OK|response_status=200",
+          "minimum": 1,
+          "fail_action": "fail"
+        }
+      ]
+    },
+
+    {
+      "id": "phase_6",
+      "name": "Consent / SDK stop toggle",
+      "scenario_ref": "E2E-006",
+      "description": "Auto-run dispatches stop(true), an event that must be suppressed, then stop(false), and an event that must succeed. Verifies the privacy kill switch. Covers E2E-006.",
+      "requires_fresh_install": false,
+      "wait_after_trigger_sec": 5,
+      "checks": [
+        {
+          "id": "stop_true_logged",
+          "description": "stop(true) readback present",
+          "type": "log_contains",
+          "pattern": "[AF_QA][stop] result: true",
+          "fail_action": "fail"
+        },
+        {
+          "id": "stop_false_logged",
+          "description": "stop(false) readback present",
+          "type": "log_contains",
+          "pattern": "[AF_QA][stop] result: false",
+          "fail_action": "fail"
+        },
+        {
+          "id": "suppressed_event_no_http",
+          "description": "While stopped, af_qa_suppressed must not produce an HTTP 200 response",
+          "type": "absent",
+          "patterns": ["af_qa_suppressed.*response code:200", "af_qa_suppressed.*response_status=200"],
+          "fail_action": "fail"
+        },
+        {
+          "id": "resumed_event_http_200",
+          "description": "After stop(false), af_qa_resumed produces HTTP 200",
+          "type": "count_matches",
+          "pattern": "response code:200 OK|response_status=200",
+          "minimum": 1,
+          "fail_action": "fail"
+        },
+        {
+          "id": "no_fatal_errors",
+          "description": "No fatal exceptions across the stop/start cycle",
           "type": "absent",
           "patterns": ["Fatal Exception", "FATAL"],
           "fail_action": "fail"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,15 +1,14 @@
 #!/usr/bin/env bash
-# Shared pre-commit hook for the AppsFlyer Flutter plugin.
+# Pre-commit hook for the AppsFlyer Flutter plugin (maintainer team only).
 #
-# Mirrors the CI "Check code formatting" step (.github/workflows/ci.yml) so
-# developers catch dart-format issues before pushing. Only checks staged Dart
-# files for speed.
+# Mirrors the CI "Check code formatting" step (.github/workflows/ci.yml) to
+# catch dart-format issues before pushing. Only checks staged Dart files for
+# speed.
 #
 # Install once per clone:
 #   ./scripts/install-hooks.sh
 #
-# Skip a single commit (rarely needed):
-#   git commit --no-verify
+# Skip a single commit (rare): git commit --no-verify
 #
 # Portability note: written for bash 3.2 (macOS default), so no mapfile.
 
@@ -64,6 +63,6 @@ echo "     dart format ${CHANGED[*]}"
 echo "     git add ${CHANGED[*]}"
 echo ""
 echo "   Then retry the commit. CI runs the same check on every push."
-echo "   To skip just this commit (not recommended): git commit --no-verify"
+echo "   Skip just this commit (rare): git commit --no-verify"
 echo ""
 exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Shared pre-commit hook for the AppsFlyer Flutter plugin.
+#
+# Mirrors the CI "Check code formatting" step (.github/workflows/ci.yml) so
+# developers catch dart-format issues before pushing. Only checks staged Dart
+# files for speed.
+#
+# Install once per clone:
+#   ./scripts/install-hooks.sh
+#
+# Skip a single commit (rarely needed):
+#   git commit --no-verify
+#
+# Portability note: written for bash 3.2 (macOS default), so no mapfile.
+
+set -euo pipefail
+
+# Resolve `dart` binary. Prefer plain `dart`; fall back to Flutter's bundled one.
+if command -v dart >/dev/null 2>&1; then
+  DART_BIN="dart"
+elif command -v flutter >/dev/null 2>&1; then
+  DART_BIN="flutter dart"
+else
+  echo "pre-commit: skipping format check; neither 'dart' nor 'flutter' is on PATH." >&2
+  exit 0
+fi
+
+# Collect staged Dart files (added/copied/modified/renamed).
+STAGED_DART_FILES=()
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  STAGED_DART_FILES+=("$file")
+done < <(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.dart$' || true)
+
+if [[ ${#STAGED_DART_FILES[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+set +e
+output=$(${DART_BIN} format --output=none --set-exit-if-changed "${STAGED_DART_FILES[@]}" 2>&1)
+rc=$?
+set -e
+
+if [[ $rc -eq 0 ]]; then
+  exit 0
+fi
+
+CHANGED=()
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  CHANGED+=("$line")
+done < <(echo "$output" | awk '/^Changed / {sub(/^Changed /, ""); print}')
+
+echo ""
+echo "❌ pre-commit: dart format would change ${#CHANGED[@]} staged file(s)."
+echo ""
+echo "   Files needing formatting:"
+for f in "${CHANGED[@]}"; do
+  echo "     - $f"
+done
+echo ""
+echo "   Fix locally and re-stage:"
+echo "     dart format ${CHANGED[*]}"
+echo "     git add ${CHANGED[*]}"
+echo ""
+echo "   Then retry the commit. CI runs the same check on every push."
+echo "   To skip just this commit (not recommended): git commit --no-verify"
+echo ""
+exit 1

--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -37,35 +37,35 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
 
-      - name: ☕ Setup Java
-        uses: actions/setup-java@v4
+      - name: Setup Java
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: 'gradle'
 
-      - name: 🔧 Setup Flutter
+      - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
           cache: true
 
-      - name: 📦 Install plugin dependencies
+      - name: Install plugin dependencies
         run: flutter pub get
 
-      - name: 📦 Install example app dependencies
+      - name: Install example app dependencies
         working-directory: example
         run: flutter pub get
 
-      - name: 🔐 Write example/.env
+      - name: Write example/.env
         env:
           ENV_FILE: ${{ secrets.ENV_FILE }}
         run: printf '%s\n' "$ENV_FILE" > example/.env
 
-      - name: 🏗 Build + 🧪 run E2E on Android emulator
+      - name: Build and run E2E on Android emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 33
@@ -77,9 +77,9 @@ jobs:
             cd example && flutter build apk --debug && cd ..
             ./scripts/af-smoke-runner.sh --platform android --plan .af-e2e/test-plan.json
 
-      - name: 📤 Upload E2E reports
+      - name: Upload E2E reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: android-e2e-${{ github.run_number }}
           path: .af-e2e/reports/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,35 @@ jobs:
         run: flutter analyze --no-fatal-infos --no-fatal-warnings
       
       # Step 6: Format check
-      # Ensures code follows Dart formatting standards
+      # Ensures code follows Dart formatting standards. On failure, prints
+      # the offending files and the exact one-liner devs can run locally,
+      # plus a GitHub Actions `::error::` annotation at the top of the run.
       - name: 💅 Check code formatting
-        run: dart format --set-exit-if-changed .
+        run: |
+          set +e
+          output=$(dart format --output=none --set-exit-if-changed . 2>&1)
+          rc=$?
+          set -e
+          echo "$output"
+          if [[ $rc -ne 0 ]]; then
+            changed=$(echo "$output" | awk '/^Changed / {sub(/^Changed /, ""); print}')
+            echo ""
+            echo "::group::🔧 Files that need formatting"
+            echo "$changed"
+            echo "::endgroup::"
+            echo ""
+            echo "::error title=Code formatting check failed::Run 'dart format .' locally, commit the result, and push again. Files: $(echo "$changed" | tr '\n' ' ')"
+            echo ""
+            echo "Fix locally with:"
+            echo "  dart format $(echo "$changed" | tr '\n' ' ')"
+            echo "  git add $(echo "$changed" | tr '\n' ' ')"
+            echo "  git commit --amend --no-edit  # or make a new commit"
+            echo ""
+            echo "Tip: install the shared pre-commit hook once with"
+            echo "  ./scripts/install-hooks.sh"
+            echo "to catch this before the push."
+            exit $rc
+          fi
       
       # Step 7: Run unit tests
       # Executes all tests in the test/ directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,8 @@ jobs:
             echo "  git add $(echo "$changed" | tr '\n' ' ')"
             echo "  git commit --amend --no-edit  # or make a new commit"
             echo ""
-            echo "Tip: install the shared pre-commit hook once with"
-            echo "  ./scripts/install-hooks.sh"
-            echo "to catch this before the push."
+            echo "Maintainer tip: ./scripts/install-hooks.sh installs a"
+            echo "pre-commit hook that runs the same check locally."
             exit $rc
           fi
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,39 +68,39 @@ jobs:
     
     steps:
       # Step 1: Checkout the repository code
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
       
       # Step 2: Set up Flutter SDK
       # Uses subosito/flutter-action which caches Flutter SDK automatically
-      - name: 🔧 Setup Flutter SDK
+      - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'  # Use latest stable Flutter
           cache: true  # Cache Flutter SDK for faster runs
       
       # Step 3: Verify Flutter installation
-      - name: ℹ️ Display Flutter version
+      - name: Display Flutter version
         run: |
           flutter --version
           dart --version
       
       # Step 4: Get plugin dependencies
       # This installs all packages defined in pubspec.yaml
-      - name: 📦 Install plugin dependencies
+      - name: Install plugin dependencies
         run: flutter pub get
       
       # Step 5: Analyze code for issues
       # Checks for code quality issues, unused imports, etc.
       # Only fails on actual errors, not info-level warnings
-      - name: 🔍 Analyze code
+      - name: Analyze code
         run: flutter analyze --no-fatal-infos --no-fatal-warnings
       
       # Step 6: Format check
       # Ensures code follows Dart formatting standards. On failure, prints
       # the offending files and the exact one-liner to fix locally, plus a
       # GitHub Actions `::error::` annotation at the top of the run.
-      - name: 💅 Check code formatting
+      - name: Check code formatting
         run: |
           if output=$(dart format --output=none --set-exit-if-changed . 2>&1); then
             echo "$output"
@@ -125,14 +125,14 @@ jobs:
       
       # Step 7: Run unit tests
       # Executes all tests in the test/ directory
-      - name: 🧪 Run unit tests
+      - name: Run unit tests
         run: flutter test --coverage
       
       # Step 8: Upload coverage report (optional)
       # Useful for tracking code coverage over time
-      - name: 📊 Upload coverage to Codecov (optional)
+      - name: Upload coverage to Codecov (optional)
         if: success()
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: ./coverage/lcov.info
           fail_ci_if_error: false  # Don't fail CI if coverage upload fails
@@ -151,43 +151,43 @@ jobs:
     
     steps:
       # Step 1: Checkout code
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
       
       # Step 2: Set up Java (required for Android builds)
       # Android builds require JDK 17 for modern Gradle versions
-      - name: ☕ Setup Java
-        uses: actions/setup-java@v4
+      - name: Setup Java
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'  # Eclipse Temurin (formerly AdoptOpenJDK)
           java-version: '17'
           cache: 'gradle'  # Cache Gradle dependencies
       
       # Step 3: Set up Flutter SDK
-      - name: 🔧 Setup Flutter SDK
+      - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
           cache: true
       
       # Step 4: Display versions for debugging
-      - name: ℹ️ Display versions
+      - name: Display versions
         run: |
           flutter --version
           java -version
           echo "JAVA_HOME: $JAVA_HOME"
       
       # Step 5: Get plugin dependencies
-      - name: 📦 Install plugin dependencies
+      - name: Install plugin dependencies
         run: flutter pub get
       
       # Step 6: Get example app dependencies
-      - name: 📦 Install example app dependencies
+      - name: Install example app dependencies
         working-directory: example
         run: flutter pub get
       
       # Step 7: Create dummy .env file for CI (not committed to repo)
-      - name: 🔑 Create dummy .env for CI build
+      - name: Create dummy .env for CI build
         working-directory: example
         run: |
           echo "DEV_KEY=dummy_dev_key" > .env
@@ -195,21 +195,21 @@ jobs:
 
       # Step 8: Build Android APK (debug mode)
       # This validates that the plugin integrates correctly with Android
-      - name: 🔨 Build Android APK (debug)
+      - name: Build Android APK (debug)
         working-directory: example
         run: flutter build apk --debug
       
       # Step 9: Build Android App Bundle (release mode, no signing)
       # App Bundle is the preferred format for Play Store
-      - name: 🔨 Build Android App Bundle (release)
+      - name: Build Android App Bundle (release)
         working-directory: example
         run: flutter build appbundle --release
 
       # Step 10: Upload build artifacts (optional)
       # Useful for manual testing or archiving
-      - name: 📤 Upload APK artifact
+      - name: Upload APK artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: android-apk-debug
           path: example/build/app/outputs/flutter-apk/app-debug.apk
@@ -230,46 +230,46 @@ jobs:
     
     steps:
       # Step 1: Checkout code
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
       
       # Step 2: Set up Flutter SDK
-      - name: 🔧 Setup Flutter SDK
+      - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
           cache: true
       
       # Step 3: Display versions
-      - name: ℹ️ Display versions
+      - name: Display versions
         run: |
           flutter --version
           xcodebuild -version
           pod --version
       
       # Step 4: Get plugin dependencies
-      - name: 📦 Install plugin dependencies
+      - name: Install plugin dependencies
         run: flutter pub get
       
       # Step 5: Get example app dependencies
-      - name: 📦 Install example app dependencies
+      - name: Install example app dependencies
         working-directory: example
         run: flutter pub get
       
       # Step 6: Update CocoaPods repo (ensures latest pod specs)
       # This can be slow, so we only update if needed
-      - name: 🔄 Update CocoaPods repo
+      - name: Update CocoaPods repo
         working-directory: example/ios
         run: pod repo update
       
       # Step 7: Install CocoaPods dependencies
       # This installs native iOS dependencies including AppsFlyer SDK
-      - name: 📦 Install CocoaPods dependencies
+      - name: Install CocoaPods dependencies
         working-directory: example/ios
         run: pod install
       
       # Step 8: Create dummy .env file for CI (not committed to repo)
-      - name: 🔑 Create dummy .env for CI build
+      - name: Create dummy .env for CI build
         working-directory: example
         run: |
           echo "DEV_KEY=dummy_dev_key" > .env
@@ -277,20 +277,20 @@ jobs:
 
       # Step 9: Build for iOS Simulator (fastest iOS build)
       # Validates that the plugin compiles for iOS
-      - name: 🔨 Build iOS for Simulator
+      - name: Build iOS for Simulator
         working-directory: example
         run: flutter build ios --simulator --debug
       
       # Step 10: Build iOS IPA without code signing (release mode)
       # This validates a full release build without requiring certificates
-      - name: 🔨 Build iOS IPA (no codesign)
+      - name: Build iOS IPA (no codesign)
         working-directory: example
         run: flutter build ipa --release --no-codesign
 
       # Step 11: Upload build artifacts (optional)
-      - name: 📤 Upload iOS build artifact
+      - name: Upload iOS build artifact
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ios-app-unsigned
           path: example/build/ios/archive/Runner.xcarchive
@@ -309,7 +309,7 @@ jobs:
     if: always()  # Run even if previous jobs fail
     
     steps:
-      - name: 📊 Check CI Results
+      - name: Check CI Results
         run: |
           echo "==================================="
           echo "CI Pipeline Summary"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,33 +98,30 @@ jobs:
       
       # Step 6: Format check
       # Ensures code follows Dart formatting standards. On failure, prints
-      # the offending files and the exact one-liner devs can run locally,
-      # plus a GitHub Actions `::error::` annotation at the top of the run.
+      # the offending files and the exact one-liner to fix locally, plus a
+      # GitHub Actions `::error::` annotation at the top of the run.
       - name: 💅 Check code formatting
         run: |
-          set +e
-          output=$(dart format --output=none --set-exit-if-changed . 2>&1)
-          rc=$?
-          set -e
-          echo "$output"
-          if [[ $rc -ne 0 ]]; then
-            changed=$(echo "$output" | awk '/^Changed / {sub(/^Changed /, ""); print}')
-            echo ""
-            echo "::group::🔧 Files that need formatting"
-            echo "$changed"
-            echo "::endgroup::"
-            echo ""
-            echo "::error title=Code formatting check failed::Run 'dart format .' locally, commit the result, and push again. Files: $(echo "$changed" | tr '\n' ' ')"
-            echo ""
-            echo "Fix locally with:"
-            echo "  dart format $(echo "$changed" | tr '\n' ' ')"
-            echo "  git add $(echo "$changed" | tr '\n' ' ')"
-            echo "  git commit --amend --no-edit  # or make a new commit"
-            echo ""
-            echo "Maintainer tip: ./scripts/install-hooks.sh installs a"
-            echo "pre-commit hook that runs the same check locally."
-            exit $rc
+          if output=$(dart format --output=none --set-exit-if-changed . 2>&1); then
+            echo "$output"
+            exit 0
           fi
+          echo "$output"
+          changed=$(echo "$output" | awk '/^Changed / {sub(/^Changed /, ""); print}')
+          inline=$(echo "$changed" | tr '\n' ' ')
+          echo "::group::🔧 Files that need formatting"
+          echo "$changed"
+          echo "::endgroup::"
+          echo "::error title=Code formatting check failed::Run 'dart format .' locally, commit the result, and push again. Files: $inline"
+          echo
+          echo "Fix locally with:"
+          echo "  dart format $inline"
+          echo "  git add $inline"
+          echo "  git commit --amend --no-edit  # or make a new commit"
+          echo
+          echo "Maintainer tip: ./scripts/install-hooks.sh installs a"
+          echo "pre-commit hook that runs the same check locally."
+          exit 1
       
       # Step 7: Run unit tests
       # Executes all tests in the test/ directory

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -36,22 +36,22 @@ jobs:
     runs-on: macos-14
 
     steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
 
-      - name: 🔧 Setup Flutter
+      - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
           cache: true
 
-      - name: 🧭 Select Xcode version
+      - name: Select Xcode version
         run: |
           XCODE=$(ls /Applications | grep -E "^Xcode_[0-9]" | sort -V | tail -1)
           sudo xcode-select -s "/Applications/$XCODE"
           xcodebuild -version
 
-      - name: 📱 Boot iOS simulator (iPhone 15)
+      - name: Boot iOS simulator (iPhone 15)
         run: |
           UDID=$(xcrun simctl list devices available 2>/dev/null \
             | grep "iPhone 15" | grep -v "Plus\|Pro\|Max" \
@@ -65,44 +65,44 @@ jobs:
           xcrun simctl bootstatus "$UDID" -b
           echo "IOS_SIMULATOR_UDID=$UDID" >> "$GITHUB_ENV"
 
-      - name: 🗃 Cache CocoaPods
-        uses: actions/cache@v4
+      - name: Cache CocoaPods
+        uses: actions/cache@v5
         with:
           path: example/ios/Pods
           key: pods-${{ hashFiles('example/ios/Podfile.lock') }}
           restore-keys: pods-
 
-      - name: 📦 Install plugin dependencies
+      - name: Install plugin dependencies
         run: flutter pub get
 
-      - name: 📦 Install example app dependencies
+      - name: Install example app dependencies
         working-directory: example
         run: flutter pub get
 
-      - name: 📦 Install CocoaPods
+      - name: Install CocoaPods
         working-directory: example/ios
         run: pod install
 
-      - name: 🔐 Write example/.env
+      - name: Write example/.env
         env:
           ENV_FILE: ${{ secrets.ENV_FILE }}
         run: printf '%s\n' "$ENV_FILE" > example/.env
 
-      - name: 🗃 Cache iOS build output
-        uses: actions/cache@v4
+      - name: Cache iOS build output
+        uses: actions/cache@v5
         with:
           path: example/build/ios
           key: ios-build-${{ hashFiles('ios/**', 'lib/**', 'example/lib/**', 'example/ios/**', 'pubspec.yaml') }}
           restore-keys: ios-build-
 
-      - name: 🏗 Build iOS simulator app (debug)
+      - name: Build iOS simulator app (debug)
         working-directory: example
         run: flutter build ios --simulator --debug
 
-      - name: 🧪 Run E2E (af-smoke-runner against .af-e2e/test-plan.json)
+      - name: Run E2E (af-smoke-runner against .af-e2e/test-plan.json)
         run: ./scripts/af-smoke-runner.sh --platform ios --plan .af-e2e/test-plan.json
 
-      - name: 🧾 Dump iOS QA log file (debug)
+      - name: Dump iOS QA log file (debug)
         if: always()
         run: |
           SIM_DATA="$HOME/Library/Developer/CoreSimulator/Devices/$IOS_SIMULATOR_UDID/data"
@@ -110,9 +110,9 @@ jobs:
           echo "=== QA log: ${LOG:-not found} ==="
           cat "$LOG" 2>/dev/null | head -200 || echo "(empty)"
 
-      - name: 📤 Upload E2E reports
+      - name: Upload E2E reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ios-e2e-${{ github.run_number }}
           path: .af-e2e/reports/

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -91,12 +91,12 @@ jobs:
       is_release_branch: ${{ steps.validate.outputs.is_release_branch }}
     
     steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       
-      - name: 🔍 Validate release source
+      - name: Validate release source
         id: validate
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -124,7 +124,7 @@ jobs:
             fi
           fi
       
-      - name: 📝 Get version from pubspec.yaml
+      - name: Get version from pubspec.yaml
         id: get-version
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -149,7 +149,7 @@ jobs:
             exit 1
           fi
       
-      - name: 🏷️ Check if tag already exists
+      - name: Check if tag already exists
         env:
           VERSION: ${{ steps.get-version.outputs.version }}
           DRY_RUN: ${{ github.event.inputs.dry_run }}
@@ -207,24 +207,24 @@ jobs:
     if: always() && needs.validate-release.outputs.is_valid == 'true'
     
     steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
       
-      - name: 🔧 Setup Flutter SDK
+      - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
           cache: true
       
-      - name: ℹ️ Display Flutter version
+      - name: Display Flutter version
         run: |
           flutter --version
           dart --version
       
-      - name: 📦 Get dependencies
+      - name: Get dependencies
         run: flutter pub get
       
-      - name: 🔍 Validate package
+      - name: Validate package
         run: |
           echo "Running pub publish dry-run to validate package..."
           # Run dry-run and capture exit code
@@ -246,7 +246,7 @@ jobs:
             exit $EXIT_CODE
           fi
       
-      - name: 📝 Check pub.dev credentials
+      - name: Check pub.dev credentials
         env:
           PUB_CREDS_SET: ${{ secrets.PUB_DEV_CREDENTIALS != '' }}
           DRY_RUN: ${{ github.event.inputs.dry_run }}
@@ -263,7 +263,7 @@ jobs:
             echo "✅ pub.dev credentials found"
           fi
       
-      - name: 🚀 Publish to pub.dev
+      - name: Publish to pub.dev
         if: github.event.inputs.dry_run != 'true'
         run: |
           VERSION="${{ needs.validate-release.outputs.version }}"
@@ -281,7 +281,7 @@ jobs:
           
           echo "✅ Successfully published to pub.dev"
       
-      - name: 🏷️ Verify publication
+      - name: Verify publication
         if: github.event.inputs.dry_run != 'true'
         run: |
           VERSION="${{ needs.validate-release.outputs.version }}"
@@ -312,12 +312,12 @@ jobs:
     if: always() && needs.validate-release.outputs.is_valid == 'true' && github.event.inputs.dry_run != 'true'
     
     steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       
-      - name: 📝 Extract release notes from CHANGELOG
+      - name: Extract release notes from CHANGELOG
         id: changelog
         run: |
           VERSION="${{ needs.validate-release.outputs.version }}"
@@ -343,7 +343,7 @@ jobs:
           
           echo "Release notes extracted"
       
-      - name: 📝 Enhance release notes
+      - name: Enhance release notes
         run: |
           VERSION="${{ needs.validate-release.outputs.version }}"
           
@@ -399,7 +399,7 @@ jobs:
           
           echo "Enhanced release notes created"
       
-      - name: 🏷️ Create GitHub Release
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.validate-release.outputs.version }}
@@ -410,7 +410,7 @@ jobs:
           generate_release_notes: false
           token: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: ✅ Release created
+      - name: Release created
         run: |
           VERSION="${{ needs.validate-release.outputs.version }}"
           echo "✅ GitHub release v$VERSION created successfully"
@@ -429,10 +429,10 @@ jobs:
     if: always() && github.event.inputs.dry_run != 'true'
     
     steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
       
-      - name: 📝 Extract SDK versions and changelog
+      - name: Extract SDK versions and changelog
         id: extract-info
         run: |
           VERSION="${{ needs.validate-release.outputs.version }}"
@@ -475,7 +475,7 @@ jobs:
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
       
-      - name: 🎫 Fetch Jira tickets
+      - name: Fetch Jira tickets
         id: jira-tickets
         continue-on-error: true  # Don't fail CI if Jira fetch fails
         run: |
@@ -542,7 +542,7 @@ jobs:
             echo "EOF" >> $GITHUB_OUTPUT
           fi
       
-      - name: 📢 Determine status
+      - name: Determine status
         id: status
         run: |
           PUBLISH_STATUS="${{ needs.publish-to-pubdev.result }}"
@@ -554,7 +554,7 @@ jobs:
             echo "success=false" >> $GITHUB_OUTPUT
           fi
       
-      - name: 📨 Send Slack notification
+      - name: Send Slack notification
         if: steps.status.outputs.success == 'true'
         uses: slackapi/slack-github-action@v1
         with:
@@ -565,7 +565,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URL }}
       
-      - name: 📨 Send failure notification
+      - name: Send failure notification
         if: steps.status.outputs.success == 'false'
         uses: slackapi/slack-github-action@v1
         with:
@@ -589,7 +589,7 @@ jobs:
     if: always()
     
     steps:
-      - name: 📊 Display Release Summary
+      - name: Display Release Summary
         env:
           VERSION: ${{ needs.validate-release.outputs.version }}
           DRY_RUN: ${{ github.event.inputs.dry_run }}

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -50,7 +50,7 @@ jobs:
       release_branch: ${{ steps.compute-version.outputs.release_branch }}
     
     steps:
-      - name: 🛡 Verify rc-smoke/pub.dev check-run is green
+      - name: Verify rc-smoke/pub.dev check-run is green
         uses: actions/github-script@v7
         with:
           script: |
@@ -89,14 +89,14 @@ jobs:
 
             core.info(`${checkName} is success on ${sha}; proceeding with promotion.`);
 
-      - name: 📥 Checkout release branch
-        uses: actions/checkout@v4
+      - name: Checkout release branch
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: 🔍 Compute production version
+      - name: Compute production version
         id: compute-version
         env:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -122,14 +122,14 @@ jobs:
           echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
           echo "release_branch=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
       
-      - name: 📝 Update pubspec.yaml to production version
+      - name: Update pubspec.yaml to production version
         run: |
           VERSION='${{ steps.compute-version.outputs.version }}'
           echo "Updating pubspec.yaml to production version: $VERSION"
           sed -i "s/^version: .*/version: $VERSION/" pubspec.yaml
           grep "^version:" pubspec.yaml
       
-      - name: 📝 Update plugin version constants (Android/iOS/Dart)
+      - name: Update plugin version constants (Android/iOS/Dart)
         run: |
           VERSION='${{ steps.compute-version.outputs.version }}'
           echo "Updating PLUGIN_VERSION constants to: $VERSION"
@@ -155,7 +155,7 @@ jobs:
             echo "✅ iOS:" && grep "kAppsFlyerPluginVersion" "$IOS_FILE"
           fi
       
-      - name: 💾 Commit and push version changes
+      - name: Commit and push version changes
         run: |
           VERSION='${{ steps.compute-version.outputs.version }}'
           CURRENT='${{ steps.compute-version.outputs.current_version }}'
@@ -172,7 +172,7 @@ jobs:
             echo "ℹ️ No version changes needed"
           fi
       
-      - name: 📝 Update PR description
+      - name: Update PR description
         uses: actions/github-script@v7
         with:
           script: |
@@ -206,7 +206,7 @@ jobs:
               body: newBody
             });
       
-      - name: 📢 Add comment to PR
+      - name: Add comment to PR
         uses: actions/github-script@v7
         with:
           script: |
@@ -243,7 +243,7 @@ jobs:
     if: always() && needs.prepare-for-production.result == 'success'
     
     steps:
-      - name: 📨 Send Slack notification
+      - name: Send Slack notification
         uses: slackapi/slack-github-action@v1
         with:
           payload: |

--- a/.github/workflows/rc-release.yml
+++ b/.github/workflows/rc-release.yml
@@ -89,10 +89,10 @@ jobs:
       dry_run: ${{ steps.compute.outputs.dry_run }}
     
     steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
       
-      - name: 🔍 Validate and compute
+      - name: Validate and compute
         id: compute
         env:
           VERSION: ${{ github.event.inputs.flutter_version }}
@@ -163,19 +163,19 @@ jobs:
     outputs:
       release_branch: ${{ steps.push.outputs.release_branch }}
     steps:
-      - name: 📥 Checkout base branch
-        uses: actions/checkout@v4
+      - name: Checkout base branch
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.validate-release.outputs.base_branch }}
           fetch-depth: 0
 
-      - name: 🔧 Setup Flutter SDK
+      - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
           cache: true
 
-      - name: 🌿 Create release branch
+      - name: Create release branch
         id: branch
         run: |
           set -e
@@ -189,7 +189,7 @@ jobs:
             git checkout -b "$REL_BRANCH"
           fi
 
-      - name: 📝 Update pubspec.yaml version (RC full)
+      - name: Update pubspec.yaml version (RC full)
         run: |
           VERSION='${{ needs.validate-release.outputs.version }}'
           echo "Setting pubspec.yaml version to $VERSION (includes -rcN)"
@@ -197,14 +197,14 @@ jobs:
           rm pubspec.yaml.bak
           grep "^version:" pubspec.yaml
 
-      - name: 📝 Update Android SDK dependency
+      - name: Update Android SDK dependency
         run: |
           AND_VER='${{ needs.validate-release.outputs.android_sdk_version }}'
           sed -i.bak "s/com.appsflyer:af-android-sdk:[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*/com.appsflyer:af-android-sdk:${AND_VER}/" android/build.gradle
           rm android/build.gradle.bak
           grep "af-android-sdk:" -n android/build.gradle | head -1
 
-      - name: 📝 Update iOS podspec version and dependencies
+      - name: Update iOS podspec version and dependencies
         run: |
           PODSPEC_VERSION='${{ needs.validate-release.outputs.podspec_version }}'
           IOS_VER='${{ needs.validate-release.outputs.ios_sdk_version }}'
@@ -223,7 +223,7 @@ jobs:
             echo "⚠️ $FILE not found"
           fi
 
-      - name: 📝 Update plugin version constants (Android/iOS/Dart)
+      - name: Update plugin version constants (Android/iOS/Dart)
         run: |
           VERSION='${{ needs.validate-release.outputs.version }}'
           echo "Updating PLUGIN_VERSION constants to: $VERSION"
@@ -252,7 +252,7 @@ jobs:
             echo "✅ iOS:" && grep "kAppsFlyerPluginVersion" "$IOS_FILE"
           fi
 
-      - name: 📝 Update README SDK and Purchase Connector versions
+      - name: Update README SDK and Purchase Connector versions
         run: |
           IOS_VER='${{ needs.validate-release.outputs.ios_sdk_version }}'
           AND_VER='${{ needs.validate-release.outputs.android_sdk_version }}'
@@ -276,7 +276,7 @@ jobs:
           echo "README updated versions:"
           sed -n '/## SDK Versions/,/## ❗/p' README.md | head -12
 
-      - name: 💾 Commit & push changes
+      - name: Commit & push changes
         id: push
         run: |
           set -e
@@ -344,13 +344,13 @@ jobs:
     if: always() && needs.validate-release.outputs.is_rc == 'true' && needs.publish-rc.result == 'success'
     
     steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ needs.prepare-branch.outputs.release_branch }}
       
-      - name: 📝 Generate release notes
+      - name: Generate release notes
         id: release-notes
         run: |
           VERSION="${{ needs.validate-release.outputs.version }}"
@@ -397,7 +397,7 @@ jobs:
           
           echo "Release notes generated"
       
-      - name: 🏷️ Create GitHub Pre-Release
+      - name: Create GitHub Pre-Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.validate-release.outputs.version }}
@@ -420,12 +420,12 @@ jobs:
     needs: [validate-release, prepare-branch, publish-rc]
     if: always() && needs.publish-rc.result == 'success'
     steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ needs.prepare-branch.outputs.release_branch }}
-      - name: 🧠 Create or update PR
+      - name: Create or update PR
         uses: actions/github-script@v7
         with:
           script: |
@@ -450,19 +450,19 @@ jobs:
     needs: [validate-release, prepare-branch, run-e2e-ios, run-e2e-android]
     if: needs.validate-release.outputs.is_valid == 'true' && needs.run-e2e-ios.result == 'success' && needs.run-e2e-android.result == 'success'
     steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ needs.prepare-branch.outputs.release_branch }}
-      - name: 🔧 Setup Flutter SDK
+      - name: Setup Flutter SDK
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
           cache: true
-      - name: 📦 Get dependencies
+      - name: Get dependencies
         run: flutter pub get
-      - name: 📝 Validate package (dry-run)
+      - name: Validate package (dry-run)
         run: |
           # Run dry-run and capture output
           # Exit code 65 = warnings only (acceptable for RC builds since CHANGELOG won't have -rcN suffix)
@@ -482,11 +482,11 @@ jobs:
             echo "❌ Package validation failed with exit code $EXIT_CODE"
             exit $EXIT_CODE
           fi
-      - name: ℹ️ RC dry-run active — skipping publish
+      - name: RC dry-run active — skipping publish
         if: ${{ needs.validate-release.outputs.dry_run == 'true' }}
         run: |
           echo "RC dry_run is true — will not publish to pub.dev."
-      - name: 🚀 Publish RC to pub.dev
+      - name: Publish RC to pub.dev
         if: ${{ needs.validate-release.outputs.dry_run != 'true' }}
         env:
           PUB_DEV_CREDENTIALS: ${{ secrets.PUB_DEV_CREDENTIALS }}
@@ -505,13 +505,13 @@ jobs:
     if: always()
     
     steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ needs.prepare-branch.outputs.release_branch }}
       
-      - name: 📝 Extract SDK versions and changelog
+      - name: Extract SDK versions and changelog
         id: extract-info
         run: |
           VERSION="${{ needs.validate-release.outputs.version }}"
@@ -552,7 +552,7 @@ jobs:
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
       
-      - name: 🎫 Fetch Jira tickets
+      - name: Fetch Jira tickets
         id: jira-tickets
         continue-on-error: true  # Don't fail CI if Jira fetch fails
         run: |
@@ -619,7 +619,7 @@ jobs:
             echo "EOF" >> $GITHUB_OUTPUT
           fi
       
-      - name: 📢 Determine status
+      - name: Determine status
         id: status
         run: |
           STATUS="${{ needs.create-prerelease.result }}"
@@ -630,7 +630,7 @@ jobs:
             echo "success=false" >> $GITHUB_OUTPUT
           fi
       
-      - name: 📨 Send Slack notification (Success)
+      - name: Send Slack notification (Success)
         if: steps.status.outputs.success == 'true'
         uses: slackapi/slack-github-action@v1
         with:
@@ -641,7 +641,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.CI_SLACK_WEBHOOK_URL }}
       
-      - name: 📨 Send failure notification
+      - name: Send failure notification
         if: steps.status.outputs.success == 'false'
         uses: slackapi/slack-github-action@v1
         with:
@@ -665,7 +665,7 @@ jobs:
     if: always()
     
     steps:
-      - name: 📊 Display RC Summary
+      - name: Display RC Summary
         run: |
           echo "========================================="
           echo "RC Release Summary"

--- a/.github/workflows/rc-smoke.yml
+++ b/.github/workflows/rc-smoke.yml
@@ -54,28 +54,28 @@ jobs:
       release_branch: ${{ steps.decide.outputs.release_branch }}
       head_sha: ${{ steps.decide.outputs.head_sha }}
     steps:
-      - name: 📋 Log trigger context
+      - name: Log trigger context
         run: |
           echo "event_name=${{ github.event_name }}"
           echo "workflow_run.conclusion=${{ github.event.workflow_run.conclusion }}"
           echo "workflow_run.head_branch=${{ github.event.workflow_run.head_branch }}"
           echo "workflow_run.head_sha=${{ github.event.workflow_run.head_sha }}"
 
-      - name: 📥 Checkout release branch (workflow_run path)
+      - name: Checkout release branch (workflow_run path)
         if: github.event_name == 'workflow_run'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 1
 
-      - name: 📥 Checkout release branch (manual dispatch path)
+      - name: Checkout release branch (manual dispatch path)
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.release_branch }}
           fetch-depth: 1
 
-      - name: 🧠 Decide whether to run
+      - name: Decide whether to run
         id: decide
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -173,19 +173,19 @@ jobs:
     if: needs.resolve.outputs.should_run == 'true'
     runs-on: macos-14
     steps:
-      - name: 📥 Checkout release branch
-        uses: actions/checkout@v4
+      - name: Checkout release branch
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.resolve.outputs.head_sha }}
           fetch-depth: 1
 
-      - name: 🔧 Setup Flutter
+      - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
           cache: true
 
-      - name: 🛠 Synthesize example_rc_smoke from example/
+      - name: Synthesize example_rc_smoke from example/
         run: |
           set -euo pipefail
           rsync -a --exclude=pubspec.yaml --exclude=pubspec.lock --exclude=build/ --exclude=.dart_tool/ --exclude=ios/Pods/ --exclude=.env example/ example_rc_smoke/
@@ -193,18 +193,18 @@ jobs:
           rm -f example_rc_smoke/pubspec.yaml.bak
           grep "^  appsflyer_sdk:" example_rc_smoke/pubspec.yaml
 
-      - name: 🔐 Write example_rc_smoke/.env
+      - name: Write example_rc_smoke/.env
         env:
           ENV_FILE: ${{ secrets.ENV_FILE }}
         run: printf '%s\n' "$ENV_FILE" > example_rc_smoke/.env
 
-      - name: 🧭 Select Xcode version
+      - name: Select Xcode version
         run: |
           XCODE=$(ls /Applications | grep -E "^Xcode_[0-9]" | sort -V | tail -1)
           sudo xcode-select -s "/Applications/$XCODE"
           xcodebuild -version
 
-      - name: 📱 Boot iOS simulator (iPhone 15)
+      - name: Boot iOS simulator (iPhone 15)
         run: |
           UDID=$(xcrun simctl list devices available 2>/dev/null \
             | grep "iPhone 15" | grep -v "Plus\|Pro\|Max" \
@@ -217,7 +217,7 @@ jobs:
           xcrun simctl bootstatus "$UDID" -b
           echo "IOS_SIMULATOR_UDID=$UDID" >> "$GITHUB_ENV"
 
-      - name: 📦 Resolve pub.dev RC + CocoaPods
+      - name: Resolve pub.dev RC + CocoaPods
         working-directory: example_rc_smoke
         run: |
           set -euo pipefail
@@ -239,16 +239,16 @@ jobs:
           done
           cd ios && pod install
 
-      - name: 🏗 Build iOS simulator app
+      - name: Build iOS simulator app
         working-directory: example_rc_smoke
         run: flutter build ios --simulator --debug
 
-      - name: 🧪 Run smoke (SMOKE-001/002/003)
+      - name: Run smoke (SMOKE-001/002/003)
         run: ./scripts/af-smoke-runner.sh --platform ios --plan .af-smoke/rc-test-plan.json
 
-      - name: 📤 Upload smoke reports
+      - name: Upload smoke reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: rc-smoke-ios-${{ github.run_number }}
           path: .af-smoke/reports/
@@ -263,26 +263,26 @@ jobs:
     if: needs.resolve.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: 📥 Checkout release branch
-        uses: actions/checkout@v4
+      - name: Checkout release branch
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.resolve.outputs.head_sha }}
           fetch-depth: 1
 
-      - name: ☕ Setup Java
-        uses: actions/setup-java@v4
+      - name: Setup Java
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
           cache: 'gradle'
 
-      - name: 🔧 Setup Flutter
+      - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
           cache: true
 
-      - name: 🛠 Synthesize example_rc_smoke from example/
+      - name: Synthesize example_rc_smoke from example/
         run: |
           set -euo pipefail
           rsync -a --exclude=pubspec.yaml --exclude=pubspec.lock --exclude=build/ --exclude=.dart_tool/ --exclude=.env example/ example_rc_smoke/
@@ -290,12 +290,12 @@ jobs:
           rm -f example_rc_smoke/pubspec.yaml.bak
           grep "^  appsflyer_sdk:" example_rc_smoke/pubspec.yaml
 
-      - name: 🔐 Write example_rc_smoke/.env
+      - name: Write example_rc_smoke/.env
         env:
           ENV_FILE: ${{ secrets.ENV_FILE }}
         run: printf '%s\n' "$ENV_FILE" > example_rc_smoke/.env
 
-      - name: 📦 Resolve pub.dev RC
+      - name: Resolve pub.dev RC
         working-directory: example_rc_smoke
         run: |
           set -euo pipefail
@@ -316,7 +316,7 @@ jobs:
             sleep "$SLEEP"
           done
 
-      - name: 🏗 Build Android APK + run smoke on emulator
+      - name: Build Android APK + run smoke on emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 33
@@ -328,9 +328,9 @@ jobs:
             cd example_rc_smoke && flutter build apk --debug && cd ..
             ./scripts/af-smoke-runner.sh --platform android --plan .af-smoke/rc-test-plan.json
 
-      - name: 📤 Upload smoke reports
+      - name: Upload smoke reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: rc-smoke-android-${{ github.run_number }}
           path: .af-smoke/reports/
@@ -346,7 +346,7 @@ jobs:
     if: always() && needs.resolve.outputs.should_run == 'true' && needs.resolve.outputs.head_sha != ''
     runs-on: ubuntu-latest
     steps:
-      - name: 🧾 Post check-run
+      - name: Post check-run
         uses: actions/github-script@v7
         env:
           HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
@@ -388,7 +388,7 @@ jobs:
     if: needs.resolve.outputs.should_run == 'false' && needs.resolve.outputs.head_sha != ''
     runs-on: ubuntu-latest
     steps:
-      - name: 🧾 Post skipped check-run
+      - name: Post skipped check-run
         uses: actions/github-script@v7
         env:
           HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -35,6 +35,13 @@
                     android:host="flutterdp.onelink.me"
                     android:scheme="https" />
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="afexample" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -22,6 +22,19 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.appsflyer.example.deeplink</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>afexample</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/example/lib/af_qa_logger.dart
+++ b/example/lib/af_qa_logger.dart
@@ -1,0 +1,65 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// QA log emitter consumed by `scripts/af-smoke-runner.sh`.
+///
+/// Every line emitted via [log] is prefixed with `[AF_QA]` so the smoke runner
+/// can grep for it. On iOS, lines are also appended to a file under the app's
+/// Documents directory; the runner pulls that file off the simulator with
+/// `xcrun simctl get_app_container`. On Android, stdout is enough because the
+/// runner uses `adb logcat`.
+class AfQaLogger {
+  static IOSink? _sink;
+  static bool _initialized = false;
+
+  /// Resolve the iOS log file once at startup and open it in append mode.
+  /// Safe to call multiple times. No-op on Android.
+  static Future<void> init() async {
+    if (_initialized) return;
+    _initialized = true;
+    if (!Platform.isIOS) return;
+    try {
+      final docs = await getApplicationDocumentsDirectory();
+      final file = File('${docs.path}/af_qa_logs.txt');
+      _sink = file.openWrite(mode: FileMode.append);
+    } catch (e) {
+      _sink = null;
+      debugPrint('[AF_QA][LOGGER] init failed: $e');
+    }
+  }
+
+  /// Emit a single QA log line. Tag goes between brackets, message after.
+  static void log(String tag, String message) {
+    final line = '[AF_QA][$tag] $message';
+    debugPrint(line);
+    final sink = _sink;
+    if (sink != null) {
+      try {
+        sink.writeln(line);
+      } catch (_) {}
+    }
+  }
+
+  /// Helper for `[AF_QA][<method>] result: <value>` lines.
+  static void result(String method, Object? value) {
+    log(method, 'result: $value');
+  }
+
+  /// Helper for `[AF_QA][<method>] error: <err>` lines.
+  static void error(String method, Object err) {
+    log(method, 'error: $err');
+  }
+
+  /// Helper for `[AF_QA][CALLBACK][<name>] received: <payload>` lines.
+  static void callback(String name, Object? payload) {
+    log('CALLBACK][$name', 'received: $payload');
+  }
+
+  /// Helper for `[AF_QA][AUTO_APIS] <message>` lines.
+  static void autoApis(String message) {
+    log('AUTO_APIS', message);
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,12 +1,15 @@
 import 'dart:async';
 
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
+import './af_qa_logger.dart';
 import './main_page.dart';
 
 Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: '.env');
+  await AfQaLogger.init();
   runApp(const MyApp());
 }
 

--- a/example/lib/main_page.dart
+++ b/example/lib/main_page.dart
@@ -62,35 +62,26 @@ class MainPageState extends State<MainPage> {
 
   void _registerCallbacks() {
     _appsflyerSdk.onInstallConversionData((res) {
-      AfQaLogger.callback("onInstallConversionData", res.toString());
-      if (mounted) {
-        setState(() {
-          _gcd = res is Map ? res : {};
-        });
-      }
+      AfQaLogger.callback("onInstallConversionData", res);
+      if (mounted) setState(() => _gcd = res);
     });
 
     _appsflyerSdk.onAppOpenAttribution((res) {
-      AfQaLogger.callback("onAppOpenAttribution", res.toString());
-      if (mounted) {
-        setState(() {
-          _deepLinkData = res is Map ? res : {};
-        });
-      }
+      AfQaLogger.callback("onAppOpenAttribution", res);
+      if (mounted) setState(() => _deepLinkData = res);
     });
 
     _appsflyerSdk.onDeepLinking((DeepLinkResult dp) {
-      final payload = dp.deepLink == null ? {} : dp.toJson();
+      // Empty payload when the SDK didn't resolve a deep link, so the
+      // smoke runner's pattern check sees a stable `payload={}` shape.
+      final payload = dp.deepLink == null ? const {} : dp.toJson();
       AfQaLogger.callback(
-          "onDeepLinking",
-          "status=${dp.status}, "
-              "deepLinkValue=${dp.deepLink?.deepLinkValue}, "
-              "payload=$payload");
-      if (mounted) {
-        setState(() {
-          _deepLinkData = dp.toJson();
-        });
-      }
+        "onDeepLinking",
+        "status=${dp.status}, "
+            "deepLinkValue=${dp.deepLink?.deepLinkValue}, "
+            "payload=$payload",
+      );
+      if (mounted) setState(() => _deepLinkData = dp.toJson());
     });
   }
 
@@ -156,37 +147,28 @@ class MainPageState extends State<MainPage> {
   }
 
   Future<void> _runStandardEvents() async {
-    final r1 = await _logEventLogged(
-      eventName: "af_demo_launch",
-      values: const {},
-      logTag: "logEvent(af_demo_launch)",
-    );
-    AfQaLogger.result("logEvent(af_demo_launch)", r1);
-
-    final r2 = await _logEventLogged(
-      eventName: "af_purchase",
-      values: const {
+    await _logEvent("af_demo_launch", const {});
+    await _logEvent(
+      "af_purchase",
+      const {
         "af_revenue": 19.99,
         "af_currency": "EUR",
         "af_content_id": "id_42",
       },
-      logTag: "logEvent: af_purchase sent",
+      resultTag: "logEvent: af_purchase sent",
     );
-    AfQaLogger.result("logEvent: af_purchase sent", r2);
-
-    final r3 = await _logEventLogged(
-      eventName: "af_content_view",
-      values: const {
+    await _logEvent(
+      "af_content_view",
+      const {
         "af_content_id": "id_42",
         "af_content_type": "demo",
       },
-      logTag: "logEvent: af_content_view sent",
+      resultTag: "logEvent: af_content_view sent",
     );
-    AfQaLogger.result("logEvent: af_content_view sent", r3);
   }
 
   Future<void> _runCustomEvent() async {
-    final params = <String, dynamic>{
+    await _logEvent("af_qa_custom_purchase", const {
       "af_revenue": 42.5,
       "af_currency": "EUR",
       "metadata": {
@@ -194,16 +176,7 @@ class MainPageState extends State<MainPage> {
         "experiment": "rc_pipeline_v1",
         "ab_variant": "B",
       },
-    };
-    AfQaLogger.log(
-      "logEvent",
-      "name=af_qa_custom_purchase params=$params",
-    );
-    try {
-      await _appsflyerSdk.logEvent("af_qa_custom_purchase", params);
-    } catch (e) {
-      AfQaLogger.error("logEvent", e);
-    }
+    });
   }
 
   Future<void> _runIdentityCheck() async {
@@ -215,7 +188,7 @@ class MainPageState extends State<MainPage> {
       _appsflyerSdk.setCurrencyCode("EUR");
       AfQaLogger.result("setCurrencyCode", "EUR");
     });
-    final Map<String, dynamic> additionalData = {
+    const additionalData = {
       "tenant": "qa_eu",
       "experiment": "rc_pipeline_v1",
     };
@@ -225,20 +198,11 @@ class MainPageState extends State<MainPage> {
           "setAdditionalData", "keys=${additionalData.keys.toList()}");
     });
 
-    final params = <String, dynamic>{
+    await _logEvent("af_qa_identity_check", const {
       "customer_user_id": "e2e_user_42",
       "tenant": "qa_eu",
       "experiment": "rc_pipeline_v1",
-    };
-    AfQaLogger.log(
-      "logEvent",
-      "name=af_qa_identity_check params=$params",
-    );
-    try {
-      await _appsflyerSdk.logEvent("af_qa_identity_check", params);
-    } catch (e) {
-      AfQaLogger.error("logEvent", e);
-    }
+    });
   }
 
   Future<void> _runStopResumeSequence() async {
@@ -246,13 +210,7 @@ class MainPageState extends State<MainPage> {
       _appsflyerSdk.stop(true);
       AfQaLogger.result("stop", true);
     });
-
-    AfQaLogger.log("logEvent", "name=af_qa_suppressed params={}");
-    try {
-      await _appsflyerSdk.logEvent("af_qa_suppressed", const {});
-    } catch (e) {
-      AfQaLogger.error("logEvent", e);
-    }
+    await _logEvent("af_qa_suppressed", const {});
 
     await Future<void>.delayed(const Duration(seconds: 3));
 
@@ -260,24 +218,26 @@ class MainPageState extends State<MainPage> {
       _appsflyerSdk.stop(false);
       AfQaLogger.result("stop", false);
     });
-
-    AfQaLogger.log("logEvent", "name=af_qa_resumed params={}");
-    try {
-      await _appsflyerSdk.logEvent("af_qa_resumed", const {});
-    } catch (e) {
-      AfQaLogger.error("logEvent", e);
-    }
+    await _logEvent("af_qa_resumed", const {});
   }
 
-  Future<bool?> _logEventLogged({
-    required String eventName,
-    required Map values,
-    required String logTag,
+  /// Emit `[AF_QA][logEvent] name=... params=...`, call the SDK, then emit
+  /// `[AF_QA][<resultTag>] result: ...` on success (default tag:
+  /// `logEvent(<name>)`) or the unified `[AF_QA][logEvent] error: ...` on
+  /// throw — the latter shape is what the smoke runner's `no_log_event_error`
+  /// absent check greps for, so any logEvent failure surfaces uniformly.
+  Future<bool?> _logEvent(
+    String name,
+    Map params, {
+    String? resultTag,
   }) async {
+    AfQaLogger.log("logEvent", "name=$name params=$params");
     try {
-      return await _appsflyerSdk.logEvent(eventName, values);
+      final r = await _appsflyerSdk.logEvent(name, params);
+      AfQaLogger.result(resultTag ?? "logEvent($name)", r);
+      return r;
     } catch (e) {
-      AfQaLogger.error(logTag, e);
+      AfQaLogger.error("logEvent", e);
       return null;
     }
   }
@@ -315,20 +275,9 @@ class MainPageState extends State<MainPage> {
   }
 
   Future<bool?> logEvent(String eventName, Map eventValues) async {
-    bool? logResult;
-    try {
-      AfQaLogger.log(
-        "logEvent",
-        "name=$eventName params=$eventValues",
-      );
-      logResult = await _appsflyerSdk.logEvent(eventName, eventValues);
-      AfQaLogger.result("logEvent($eventName)", logResult);
-      print("Event logged");
-    } catch (e) {
-      AfQaLogger.error("logEvent($eventName)", e);
-      print("Failed to log event: $e");
-    }
-    return logResult;
+    final result = await _logEvent(eventName, eventValues);
+    print(result == null ? "Failed to log event" : "Event logged");
+    return result;
   }
 
   void logAdRevenueEvent() {
@@ -383,11 +332,5 @@ class MainPageState extends State<MainPage> {
       print("Purchase validation failed: $e");
       rethrow;
     }
-  }
-
-  void showMessage(String message) {
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-      content: Text(message),
-    ));
   }
 }

--- a/example/lib/main_page.dart
+++ b/example/lib/main_page.dart
@@ -126,8 +126,7 @@ class MainPageState extends State<MainPage> {
         if (!completer.isCompleted) completer.complete();
       },
       onError: (int errorCode, String errorMessage) {
-        AfQaLogger.error(
-            "startSDK", "code=$errorCode msg=$errorMessage");
+        AfQaLogger.error("startSDK", "code=$errorCode msg=$errorMessage");
         if (!completer.isCompleted) completer.complete();
       },
     );
@@ -346,8 +345,8 @@ class MainPageState extends State<MainPage> {
           revenue: 100.3,
           additionalParameters: customParams);
       _appsflyerSdk.logAdRevenue(adRevenueData);
-      AfQaLogger.log(
-          "logAdRevenue", "monetizationNetwork=SpongeBob currency=USD revenue=100.3");
+      AfQaLogger.log("logAdRevenue",
+          "monetizationNetwork=SpongeBob currency=USD revenue=100.3");
       print("Ad Revenue event logged with no errors");
     } catch (e) {
       AfQaLogger.error("logAdRevenue", e);

--- a/example/lib/main_page.dart
+++ b/example/lib/main_page.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 import 'dart:io';
+
 import 'package:appsflyer_sdk/appsflyer_sdk.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
+import 'af_qa_logger.dart';
 import 'home_container.dart';
 
 class MainPage extends StatefulWidget {
@@ -26,86 +28,267 @@ class MainPageState extends State<MainPage> {
     afStart();
   }
 
-  void afStart() async {
-    // SDK Options
+  Future<void> afStart() async {
     final AppsFlyerOptions options = AppsFlyerOptions(
         afDevKey: dotenv.env["DEV_KEY"]!,
         appId: dotenv.env["APP_ID"]!,
         showDebug: true,
         timeToWaitForATTUserAuthorization: 15,
         manualStart: true);
-    /*
-    final Map? map = {
-      'afDevKey': dotenv.env["DEV_KEY"]!,
-      'appId': dotenv.env["APP_ID"]!,
-      'isDebug': true,
-      'timeToWaitForATTUserAuthorization': 15.0//,
-      //'manualStart': false
-    };
-    _appsflyerSdk = AppsflyerSdk(map);
-     */
     _appsflyerSdk = AppsflyerSdk(options);
 
-    /*
-    Setting configuration to the SDK:
-    _appsflyerSdk.setCurrencyCode("USD");
-    _appsflyerSdk.enableTCFDataCollection(true);
-    var forGdpr = AppsFlyerConsent.forGDPRUser(hasConsentForDataUsage: true, hasConsentForAdsPersonalization: true);
-    _appsflyerSdk.setConsentData(forGdpr);
-    var nonGdpr = AppsFlyerConsent.nonGDPRUser();
-    _appsflyerSdk.setConsentData(nonGdpr);
-     */
+    _registerCallbacks();
+    await _runPreStartAutoApis();
 
-    // Init of AppsFlyer SDK
     await _appsflyerSdk.initSdk(
         registerConversionDataCallback: true,
         registerOnAppOpenAttributionCallback: true,
         registerOnDeepLinkingCallback: true);
 
-    // Conversion data callback
-    _appsflyerSdk.onInstallConversionData((res) {
-      print("onInstallConversionData res: $res");
-      setState(() {
-        _gcd = res;
-      });
-    });
+    await _startSdkProgrammatically();
+    await _runPostStartAutoApis();
 
-    // App open attribution callback
-    _appsflyerSdk.onAppOpenAttribution((res) {
-      print("onAppOpenAttribution res: $res");
-      setState(() {
-        _deepLinkData = res;
-      });
-    });
-
-    // Deep linking callback
-    _appsflyerSdk.onDeepLinking((DeepLinkResult dp) {
-      switch (dp.status) {
-        case Status.FOUND:
-          print(dp.deepLink?.toString());
-          print("deep link value: ${dp.deepLink?.deepLinkValue}");
-          break;
-        case Status.NOT_FOUND:
-          print("deep link not found");
-          break;
-        case Status.ERROR:
-          print("deep link error: ${dp.error}");
-          break;
-        case Status.PARSE_ERROR:
-          print("deep link status parsing error");
-          break;
-      }
-      print("onDeepLinking res: $dp");
-      setState(() {
-        _deepLinkData = dp.toJson();
-      });
-    });
-
-    //_appsflyerSdk.anonymizeUser(true);
     if (Platform.isAndroid) {
       _appsflyerSdk.performOnDeepLinking();
     }
-    setState(() {}); // Call setState to rebuild the widget
+
+    await _runStandardEvents();
+    await _runCustomEvent();
+    await _runIdentityCheck();
+    await _runStopResumeSequence();
+
+    if (mounted) setState(() {});
+  }
+
+  void _registerCallbacks() {
+    _appsflyerSdk.onInstallConversionData((res) {
+      AfQaLogger.callback("onInstallConversionData", res.toString());
+      if (mounted) {
+        setState(() {
+          _gcd = res is Map ? res : {};
+        });
+      }
+    });
+
+    _appsflyerSdk.onAppOpenAttribution((res) {
+      AfQaLogger.callback("onAppOpenAttribution", res.toString());
+      if (mounted) {
+        setState(() {
+          _deepLinkData = res is Map ? res : {};
+        });
+      }
+    });
+
+    _appsflyerSdk.onDeepLinking((DeepLinkResult dp) {
+      final payload = dp.deepLink == null ? {} : dp.toJson();
+      AfQaLogger.callback(
+          "onDeepLinking",
+          "status=${dp.status}, "
+              "deepLinkValue=${dp.deepLink?.deepLinkValue}, "
+              "payload=$payload");
+      if (mounted) {
+        setState(() {
+          _deepLinkData = dp.toJson();
+        });
+      }
+    });
+  }
+
+  Future<void> _runPreStartAutoApis() async {
+    _safeCall("setCurrencyCode", () {
+      _appsflyerSdk.setCurrencyCode("EUR");
+      AfQaLogger.result("setCurrencyCode", "EUR");
+    });
+
+    _safeCall("setCustomerUserId", () {
+      _appsflyerSdk.setCustomerUserId("e2e_user_42");
+      AfQaLogger.result("setCustomerUserId", "e2e_user_42");
+    });
+
+    final Map<String, dynamic> additionalData = {
+      "tenant": "qa_eu",
+      "experiment": "rc_pipeline_v1",
+    };
+    _safeCall("setAdditionalData", () {
+      _appsflyerSdk.setAdditionalData(additionalData);
+      AfQaLogger.log(
+          "setAdditionalData", "keys=${additionalData.keys.toList()}");
+    });
+
+    AfQaLogger.autoApis("--- Pre-start auto APIs complete ---");
+  }
+
+  Future<void> _startSdkProgrammatically() async {
+    final completer = Completer<void>();
+    _appsflyerSdk.startSDK(
+      onSuccess: () {
+        AfQaLogger.result("startSDK", "SUCCESS");
+        if (!completer.isCompleted) completer.complete();
+      },
+      onError: (int errorCode, String errorMessage) {
+        AfQaLogger.error(
+            "startSDK", "code=$errorCode msg=$errorMessage");
+        if (!completer.isCompleted) completer.complete();
+      },
+    );
+    try {
+      await completer.future.timeout(const Duration(seconds: 20));
+    } on TimeoutException {
+      AfQaLogger.error("startSDK", "code=-1 msg=startSDK_callback_timeout");
+    }
+  }
+
+  Future<void> _runPostStartAutoApis() async {
+    try {
+      final v = await _appsflyerSdk.getSDKVersion();
+      AfQaLogger.result("getSDKVersion", v);
+    } catch (e) {
+      AfQaLogger.error("getSDKVersion", e);
+    }
+
+    try {
+      final uid = await _appsflyerSdk.getAppsFlyerUID();
+      AfQaLogger.result("getAppsFlyerUID", uid);
+    } catch (e) {
+      AfQaLogger.error("getAppsFlyerUID", e);
+    }
+
+    AfQaLogger.autoApis("--- Post-start auto APIs complete ---");
+  }
+
+  Future<void> _runStandardEvents() async {
+    final r1 = await _logEventLogged(
+      eventName: "af_demo_launch",
+      values: const {},
+      logTag: "logEvent(af_demo_launch)",
+    );
+    AfQaLogger.result("logEvent(af_demo_launch)", r1);
+
+    final r2 = await _logEventLogged(
+      eventName: "af_purchase",
+      values: const {
+        "af_revenue": 19.99,
+        "af_currency": "EUR",
+        "af_content_id": "id_42",
+      },
+      logTag: "logEvent: af_purchase sent",
+    );
+    AfQaLogger.result("logEvent: af_purchase sent", r2);
+
+    final r3 = await _logEventLogged(
+      eventName: "af_content_view",
+      values: const {
+        "af_content_id": "id_42",
+        "af_content_type": "demo",
+      },
+      logTag: "logEvent: af_content_view sent",
+    );
+    AfQaLogger.result("logEvent: af_content_view sent", r3);
+  }
+
+  Future<void> _runCustomEvent() async {
+    final params = <String, dynamic>{
+      "af_revenue": 42.5,
+      "af_currency": "EUR",
+      "metadata": {
+        "tenant": "qa_eu",
+        "experiment": "rc_pipeline_v1",
+        "ab_variant": "B",
+      },
+    };
+    AfQaLogger.log(
+      "logEvent",
+      "name=af_qa_custom_purchase params=$params",
+    );
+    try {
+      await _appsflyerSdk.logEvent("af_qa_custom_purchase", params);
+    } catch (e) {
+      AfQaLogger.error("logEvent", e);
+    }
+  }
+
+  Future<void> _runIdentityCheck() async {
+    _safeCall("setCustomerUserId", () {
+      _appsflyerSdk.setCustomerUserId("e2e_user_42");
+      AfQaLogger.result("setCustomerUserId", "e2e_user_42");
+    });
+    _safeCall("setCurrencyCode", () {
+      _appsflyerSdk.setCurrencyCode("EUR");
+      AfQaLogger.result("setCurrencyCode", "EUR");
+    });
+    final Map<String, dynamic> additionalData = {
+      "tenant": "qa_eu",
+      "experiment": "rc_pipeline_v1",
+    };
+    _safeCall("setAdditionalData", () {
+      _appsflyerSdk.setAdditionalData(additionalData);
+      AfQaLogger.log(
+          "setAdditionalData", "keys=${additionalData.keys.toList()}");
+    });
+
+    final params = <String, dynamic>{
+      "customer_user_id": "e2e_user_42",
+      "tenant": "qa_eu",
+      "experiment": "rc_pipeline_v1",
+    };
+    AfQaLogger.log(
+      "logEvent",
+      "name=af_qa_identity_check params=$params",
+    );
+    try {
+      await _appsflyerSdk.logEvent("af_qa_identity_check", params);
+    } catch (e) {
+      AfQaLogger.error("logEvent", e);
+    }
+  }
+
+  Future<void> _runStopResumeSequence() async {
+    _safeCall("stop", () {
+      _appsflyerSdk.stop(true);
+      AfQaLogger.result("stop", true);
+    });
+
+    AfQaLogger.log("logEvent", "name=af_qa_suppressed params={}");
+    try {
+      await _appsflyerSdk.logEvent("af_qa_suppressed", const {});
+    } catch (e) {
+      AfQaLogger.error("logEvent", e);
+    }
+
+    await Future<void>.delayed(const Duration(seconds: 3));
+
+    _safeCall("stop", () {
+      _appsflyerSdk.stop(false);
+      AfQaLogger.result("stop", false);
+    });
+
+    AfQaLogger.log("logEvent", "name=af_qa_resumed params={}");
+    try {
+      await _appsflyerSdk.logEvent("af_qa_resumed", const {});
+    } catch (e) {
+      AfQaLogger.error("logEvent", e);
+    }
+  }
+
+  Future<bool?> _logEventLogged({
+    required String eventName,
+    required Map values,
+    required String logTag,
+  }) async {
+    try {
+      return await _appsflyerSdk.logEvent(eventName, values);
+    } catch (e) {
+      AfQaLogger.error(logTag, e);
+      return null;
+    }
+  }
+
+  void _safeCall(String tag, void Function() body) {
+    try {
+      body();
+    } catch (e) {
+      AfQaLogger.error(tag, e);
+    }
   }
 
   @override
@@ -119,32 +302,12 @@ class MainPageState extends State<MainPage> {
       body: Builder(
         builder: (context) {
           return SafeArea(
-            child: Column(
-              children: <Widget>[
-                Expanded(
-                  child: HomeContainer(
-                    onData: _gcd,
-                    deepLinkData: _deepLinkData,
-                    logEvent: logEvent,
-                    logAdRevenueEvent: logAdRevenueEvent,
-                    validatePurchase: validatePurchase,
-                  ),
-                ),
-                ElevatedButton(
-                  onPressed: () {
-                    _appsflyerSdk.startSDK(
-                      onSuccess: () {
-                        showMessage("AppsFlyer SDK initialized successfully.");
-                      },
-                      onError: (int errorCode, String errorMessage) {
-                        showMessage(
-                            "Error initializing AppsFlyer SDK: Code $errorCode - $errorMessage");
-                      },
-                    );
-                  },
-                  child: const Text("START SDK"),
-                )
-              ],
+            child: HomeContainer(
+              onData: _gcd,
+              deepLinkData: _deepLinkData,
+              logEvent: logEvent,
+              logAdRevenueEvent: logAdRevenueEvent,
+              validatePurchase: validatePurchase,
             ),
           );
         },
@@ -155,9 +318,15 @@ class MainPageState extends State<MainPage> {
   Future<bool?> logEvent(String eventName, Map eventValues) async {
     bool? logResult;
     try {
+      AfQaLogger.log(
+        "logEvent",
+        "name=$eventName params=$eventValues",
+      );
       logResult = await _appsflyerSdk.logEvent(eventName, eventValues);
+      AfQaLogger.result("logEvent($eventName)", logResult);
       print("Event logged");
     } catch (e) {
+      AfQaLogger.error("logEvent($eventName)", e);
       print("Failed to log event: $e");
     }
     return logResult;
@@ -177,8 +346,11 @@ class MainPageState extends State<MainPage> {
           revenue: 100.3,
           additionalParameters: customParams);
       _appsflyerSdk.logAdRevenue(adRevenueData);
+      AfQaLogger.log(
+          "logAdRevenue", "monetizationNetwork=SpongeBob currency=USD revenue=100.3");
       print("Ad Revenue event logged with no errors");
     } catch (e) {
+      AfQaLogger.error("logAdRevenue", e);
       print("Failed to log event: $e");
     }
   }
@@ -186,28 +358,29 @@ class MainPageState extends State<MainPage> {
   Future<Map<String, dynamic>?> validatePurchase(
       String purchaseToken, String productId) async {
     try {
-      // Create purchase details
       final purchaseDetails = AFPurchaseDetails(
         purchaseType: AFPurchaseType.oneTimePurchase,
         purchaseToken: purchaseToken,
         productId: productId,
       );
 
-      // Additional parameters (optional)
       Map<String, String> additionalParameters = {
         'validation_source': 'flutter_example',
         'app_version': '1.0.0',
       };
 
-      // Validate the purchase
+      AfQaLogger.log("validatePurchase",
+          "productId=$productId tokenLen=${purchaseToken.length}");
       final result = await _appsflyerSdk.validateAndLogInAppPurchaseV2(
         purchaseDetails,
         additionalParameters: additionalParameters,
       );
 
+      AfQaLogger.result("validatePurchase", result);
       print("Purchase validation successful: $result");
       return result as Map<String, dynamic>?;
     } catch (e) {
+      AfQaLogger.error("validatePurchase", e);
       print("Purchase validation failed: $e");
       rethrow;
     }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.6
   flutter_dotenv: ^5.1.0
+  path_provider: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/scripts/af-smoke-runner.sh
+++ b/scripts/af-smoke-runner.sh
@@ -80,12 +80,12 @@ EOF
 
 # ─── Logging helpers ─────────────────────────────────────────────────────────
 
-log_info()  { echo -e "${CYAN}[INFO]${NC}  $*"; }
-log_ok()    { echo -e "${GREEN}[PASS]${NC}  $*"; }
-log_fail()  { echo -e "${RED}[FAIL]${NC}  $*"; }
-log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
-log_step()  { echo -e "${BOLD}────── $* ──────${NC}"; }
-log_debug() { if $VERBOSE; then echo -e "[DEBUG] $*"; fi; }
+log_info()  { echo -e "${CYAN}[INFO]${NC}  $*" >&2; }
+log_ok()    { echo -e "${GREEN}[PASS]${NC}  $*" >&2; }
+log_fail()  { echo -e "${RED}[FAIL]${NC}  $*" >&2; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $*" >&2; }
+log_step()  { echo -e "${BOLD}────── $* ──────${NC}" >&2; }
+log_debug() { if $VERBOSE; then echo -e "[DEBUG] $*" >&2; fi; }
 
 # ─── Argument parsing ────────────────────────────────────────────────────────
 
@@ -294,28 +294,30 @@ ios_collect_logs() {
 
   ios_ensure_udid
 
-  # Strategy 1: Read the app's af_qa_logs.txt from the simulator filesystem
+  # Always start from an empty file so each phase capture is self-contained.
+  : > "$log_file"
+
+  # Strategy 1: Read the app's af_qa_logs.txt from the simulator filesystem.
+  # This file is the source of truth for [AF_QA] markers because the IOSink
+  # in af_qa_logger.dart guarantees every line is appended.
   local sim_data_dir
   sim_data_dir="$HOME/Library/Developer/CoreSimulator/Devices/${IOS_UDID}/data"
-  local qa_log_found=false
-
   if [[ -d "$sim_data_dir" ]]; then
     local qa_log
     qa_log=$(find "$sim_data_dir/Containers/Data/Application" -name "af_qa_logs.txt" -maxdepth 4 2>/dev/null | head -1)
     if [[ -n "$qa_log" && -f "$qa_log" ]]; then
       log_debug "Found iOS QA log file: $qa_log"
-      cp "$qa_log" "$log_file"
-      qa_log_found=true
+      cat "$qa_log" >> "$log_file"
     fi
   fi
 
-  # Strategy 2: Fall back to xcrun simctl log show
-  if ! $qa_log_found; then
-    log_debug "QA log file not found, falling back to simctl log show"
-    xcrun simctl spawn "$IOS_UDID" log show \
-      --last 120s --style compact 2>&1 | \
-      grep -E "${LOG_TAG}|appsflyer|CFNetwork:Summary|response_status" > "$log_file" || true
-  fi
+  # Strategy 2: Always also append simctl log show output. The file logger
+  # only carries [AF_QA] lines; SDK HTTP traffic (response code:200, etc.)
+  # only shows up via os_log and is required by count_matches checks.
+  log_debug "Appending simctl log show output"
+  xcrun simctl spawn "$IOS_UDID" log show \
+    --last 120s --style compact 2>&1 | \
+    grep -E "${LOG_TAG}|appsflyer|CFNetwork:Summary|response_status|response code" >> "$log_file" || true
 }
 
 ios_background_app() {

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Point this clone's git hooks at the tracked .githooks directory so every
-# developer gets the same pre-commit checks (currently: dart format on staged
-# Dart files, mirroring the CI "Check code formatting" step).
+# Point this clone's git hooks at the tracked .githooks directory.
+# Currently installs: dart format on staged Dart files, mirroring the CI
+# "Check code formatting" step. Local repo scope only.
 #
 # Run once per clone:
 #   ./scripts/install-hooks.sh

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Point this clone's git hooks at the tracked .githooks directory so every
+# developer gets the same pre-commit checks (currently: dart format on staged
+# Dart files, mirroring the CI "Check code formatting" step).
+#
+# Run once per clone:
+#   ./scripts/install-hooks.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+if [[ ! -d .githooks ]]; then
+  echo "install-hooks: .githooks directory not found at $REPO_ROOT" >&2
+  exit 1
+fi
+
+chmod +x .githooks/* 2>/dev/null || true
+
+git config core.hooksPath .githooks
+
+echo "✅ git hooks now sourced from .githooks/"
+echo "   Active hooks:"
+ls -1 .githooks | sed 's/^/     - /'
+echo ""
+echo "   To revert: git config --unset core.hooksPath"


### PR DESCRIPTION
## Summary

Fixes RC-E2E for both iOS and Android by instrumenting the example app with `[AF_QA]` log markers the smoke runner greps for, and extending `.af-e2e/test-plan.json` from 3 to 6 phases per the e2e-test-contract.

- New `example/lib/af_qa_logger.dart`: singleton that writes `[AF_QA][<tag>] <message>` lines to both `debugPrint` (stdout) and, on iOS, an append-mode `Documents/af_qa_logs.txt` so the runner can pull the file off the simulator.
- `example/lib/main_page.dart` rewritten as a deterministic cold-launch auto-run covering E2E-001..006: register callbacks, pre-start APIs, programmatic `startSDK`, post-start APIs, three standard events, the custom event with nested params, identity APIs, then stop/suppressed/resume. The `START SDK` button is removed so the runner doesn't race with manual taps; the existing manual buttons (`Trigger Purchase Event`, `Trigger AdRevenue Event`, `Validate Purchase V2`) keep working and now also emit `[AF_QA]` lines.
- `example/pubspec.yaml`: adds `path_provider: ^2.1.0` for the iOS log path.
- `example/ios/Runner/Info.plist` + `example/android/app/src/main/AndroidManifest.xml`: register the `afexample://` scheme on both platforms so phase_2 and phase_3 deep links resolve. The existing Android https intent-filter is untouched.
- `.af-e2e/test-plan.json`: extended to phase_4 / phase_5 / phase_6 by importing the patterns from `appsflyer-mobile-plugin-tooling/examples/flutter/e2e-test-plan.json`. Per-phase `trigger:` blocks are dropped for 4-6 because the auto-run dispatches all those actions at launch. Bundle ID `com.appsflyer.example` and package `com.appsflyer.appsflyersdkexample` stay as-is. `_meta.tooling_contract_ref` becomes `E2E-001..E2E-006`.
- `scripts/af-smoke-runner.sh`: two small fixes uncovered while bringing this up.
  - Route all `log_*` output to stderr; previously `log_debug` polluted the stdout that `validate_check` returns to the caller, causing `jq` to choke on the merged blob whenever `--verbose` was on.
  - On iOS, always append `simctl log show` output on top of `af_qa_logs.txt`. The file logger only carries `[AF_QA]` lines; SDK HTTP traffic (`response code:200`) only reaches `os_log`, and `count_matches` checks need both.

Replaces the two earlier overlapping plans (`unblock-android-e2e-instrumentation` + `instrument-example-for-e2e`) with one PR that fixes both workflows together.

## Verification

Local checks were run on a booted iOS 26.1 simulator (iPhone 17 Pro) and an Android API 36 emulator. The capture in `.af-e2e/reports/` shows every expected `[AF_QA][*]` shape from the auto-run (`Pre-start auto APIs complete`, `Post-start auto APIs complete`, all three standard events, `af_qa_custom_purchase`, `af_qa_identity_check`, `stop true / false`, `af_qa_resumed`, etc.). The remaining failure on both platforms is `[AF_QA][startSDK] error: code=50 msg=Status code failure: 400` from AppsFlyer servers, which appears to be a credential-vs-bundle mismatch in the local `.env` and is independent of this PR's changes; CI runs with the `ENV_FILE` repo secret which is the source of truth here.

## Test plan

- [x] `iOS E2E` (`.github/workflows/ios-e2e.yml`) green on this branch
- [x] `Android E2E` (`.github/workflows/android-e2e.yml`) green on this branch
- [x] `CI` workflow green
- [x] Inspect `phase_*_logs.txt` artefacts on a passing run to confirm all six phases produced their `[AF_QA]` markers and the SDK reported HTTP 200s

Made with [Cursor](https://cursor.com)