### PR TITLE
Fix rc-smoke.yml resolving the wrong branch on automatic trigger

### DIFF
--- a/.github/workflows/rc-smoke.yml
+++ b/.github/workflows/rc-smoke.yml
@@ -60,12 +60,66 @@ jobs:
           echo "workflow_run.conclusion=${{ github.event.workflow_run.conclusion }}"
           echo "workflow_run.head_branch=${{ github.event.workflow_run.head_branch }}"
           echo "workflow_run.head_sha=${{ github.event.workflow_run.head_sha }}"
+          echo "workflow_run.updated_at=${{ github.event.workflow_run.updated_at }}"
+
+      # workflow_run events only ever expose head_sha/head_branch for the ref
+      # rc-release.yml was *dispatched with* (e.g. development) — never the
+      # releases/** branch that its own prepare-branch job creates during the
+      # run. Trusting head_sha/head_branch here was the root cause of smoke
+      # silently no-op'ing on every automatic run: it always checked out
+      # development (still at the last real release's version), saw a
+      # non-RC version string, and skipped. Instead, resolve the actual RC
+      # from the GitHub prerelease that create-prerelease just published —
+      # that's the one artifact this job CAN see that unambiguously points at
+      # the real release.
+      - name: Resolve RC version and branch from latest GitHub prerelease (workflow_run path)
+        if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+        id: resolve-prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PARENT_UPDATED_AT: ${{ github.event.workflow_run.updated_at }}
+        run: |
+          set -euo pipefail
+          LATEST=$(gh api "repos/${{ github.repository }}/releases" --jq '[.[] | select(.prerelease == true)] | sort_by(.created_at) | last')
+          TAG=$(echo "$LATEST" | jq -r '.tag_name // empty')
+          CREATED_AT=$(echo "$LATEST" | jq -r '.created_at // empty')
+          if [[ -z "$TAG" ]]; then
+            echo "No prerelease found on the repo; cannot resolve RC context."
+            echo "resolved_version=" >> "$GITHUB_OUTPUT"
+            echo "resolved_branch=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Sanity check: the prerelease should have been published around
+          # the same time this triggering run finished. If it's more than 30
+          # minutes off, it's likely a stale or unrelated tag rather than the
+          # one this specific run produced — don't trust it.
+          CREATED_EPOCH=$(date -d "$CREATED_AT" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$CREATED_AT" +%s)
+          PARENT_EPOCH=$(date -d "$PARENT_UPDATED_AT" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$PARENT_UPDATED_AT" +%s)
+          if (( CREATED_EPOCH > PARENT_EPOCH )); then
+            DIFF=$(( CREATED_EPOCH - PARENT_EPOCH ))
+          else
+            DIFF=$(( PARENT_EPOCH - CREATED_EPOCH ))
+          fi
+          if (( DIFF > 1800 )); then
+            echo "Latest prerelease $TAG was created ${DIFF}s away from this run's completion — too stale to trust, skipping."
+            echo "resolved_version=" >> "$GITHUB_OUTPUT"
+            echo "resolved_branch=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          MAJOR_MINOR=$(echo "$TAG" | grep -oE '^[0-9]+\.[0-9]+')
+          MAJOR=$(echo "$TAG" | grep -oE '^[0-9]+')
+          BRANCH="releases/${MAJOR}.x.x/${MAJOR_MINOR}.x/${TAG}"
+          echo "Resolved latest prerelease $TAG -> release branch $BRANCH"
+          echo "resolved_version=$TAG" >> "$GITHUB_OUTPUT"
+          echo "resolved_branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Checkout release branch (workflow_run path)
-        if: github.event_name == 'workflow_run'
+        if: github.event_name == 'workflow_run' && steps.resolve-prerelease.outputs.resolved_branch != ''
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ steps.resolve-prerelease.outputs.resolved_branch }}
           fetch-depth: 1
 
       - name: Checkout release branch (manual dispatch path)
@@ -80,8 +134,8 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           PARENT_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RESOLVED_VERSION: ${{ steps.resolve-prerelease.outputs.resolved_version }}
+          RESOLVED_BRANCH: ${{ steps.resolve-prerelease.outputs.resolved_branch }}
           INPUT_VERSION: ${{ github.event.inputs.rc_version }}
           INPUT_BRANCH: ${{ github.event.inputs.release_branch }}
         run: |
@@ -104,28 +158,39 @@ jobs:
             echo "Parent RC-release run was $PARENT_CONCLUSION; skipping smoke."
             echo "should_run=false" >> "$GITHUB_OUTPUT"
             echo "skip_reason=parent_not_success" >> "$GITHUB_OUTPUT"
-            echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
-            echo "release_branch=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "head_sha=" >> "$GITHUB_OUTPUT"
+            echo "release_branch=" >> "$GITHUB_OUTPUT"
             echo "rc_version=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # workflow_run listeners cannot read the parent's inputs directly,
-          # so we infer state from the release branch checkout: pubspec.yaml
-          # carries the bumped RC version (committed by prepare-branch on both
-          # real and dry runs), and the pub.dev API tells us if it was
-          # actually published. Dry runs naturally fail the visibility poll
-          # below and emit a skipped check-run.
-          VERSION=$(grep "^version:" pubspec.yaml | sed 's/version: //' | tr -d ' ')
-          if [[ ! "$VERSION" =~ -rc[0-9]+$ ]]; then
-            echo "pubspec version is not an RC ($VERSION); skipping."
+          if [[ -z "$RESOLVED_BRANCH" ]]; then
+            echo "Could not resolve a release branch from any recent prerelease; skipping."
             echo "should_run=false" >> "$GITHUB_OUTPUT"
-            echo "skip_reason=not_rc_version" >> "$GITHUB_OUTPUT"
-            echo "rc_version=$VERSION" >> "$GITHUB_OUTPUT"
-            echo "release_branch=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
-            echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=could_not_resolve_release_branch" >> "$GITHUB_OUTPUT"
+            echo "rc_version=$RESOLVED_VERSION" >> "$GITHUB_OUTPUT"
+            echo "release_branch=" >> "$GITHUB_OUTPUT"
+            echo "head_sha=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          # Defensive re-check against the branch we actually checked out —
+          # the resolved tag should match what prepare-branch committed to
+          # pubspec.yaml on that branch. Belt-and-suspenders, not the primary
+          # signal anymore.
+          VERSION=$(grep "^version:" pubspec.yaml | sed 's/version: //' | tr -d ' ')
+          if [[ "$VERSION" != "$RESOLVED_VERSION" || ! "$VERSION" =~ -rc[0-9]+$ ]]; then
+            echo "Resolved prerelease tag ($RESOLVED_VERSION) doesn't match pubspec.yaml on $RESOLVED_BRANCH ($VERSION); skipping."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=version_mismatch" >> "$GITHUB_OUTPUT"
+            echo "rc_version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "release_branch=$RESOLVED_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "head_sha=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          HEAD_SHA="$(git rev-parse HEAD)"
+          HEAD_BRANCH="$RESOLVED_BRANCH"
 
           # Pub.dev indexing can lag a few minutes after a successful publish.
           # Poll the API until the RC version appears, with a hard timeout.


### PR DESCRIPTION
## Summary
`rc-smoke.yml`'s automatic (`workflow_run`) trigger has never actually smoke-tested a real RC since it was added in #446 (2026-04-26). Root cause: `workflow_run` events only expose `head_sha`/`head_branch` for the ref `rc-release.yml` was **dispatched with** (e.g. `development`), never the `releases/**` branch its own `prepare-branch` job creates *during* the run. So every automatic smoke run checked out `development`, saw its stale (last real release's) `pubspec.yaml` version, concluded "not an RC," and silently skipped — with `conclusion: success`, so nothing ever flagged it as broken.

Confirmed directly against the `6.18.1-rc1`/`rc2` RCs cut in this session: both automatic smoke runs skipped with `pubspec version is not an RC (6.18.0); skipping.` The manual `workflow_dispatch` path (with explicit `rc_version`/`release_branch` inputs) was unaffected and worked correctly both times.

## Fix
Instead of trusting `workflow_run.head_sha`/`head_branch`, resolve the actual RC from the GitHub prerelease that `create-prerelease` just published:
- Query `GET /repos/{owner}/{repo}/releases`, filter to `prerelease: true`, take the most recently created one.
- Sanity-check its `created_at` is within 30 minutes of the triggering run's completion (`workflow_run.updated_at`) — guards against picking up a stale/unrelated tag.
- Derive the release branch from the tag using the same `releases/${MAJOR}.x.x/${MAJOR_MINOR}.x/${VERSION}` convention `rc-release.yml` already computes.
- Check out that branch, and keep a defensive re-check that `pubspec.yaml` on it actually matches the resolved version.

No new secrets required — this only reads public release metadata via the default `GITHUB_TOKEN`.

## Test plan
- [x] `ruby -ryaml -e "YAML.load_file(...)"` — valid YAML.
- [ ] Next real RC cut should show `rc-smoke/pub.dev` actually running (not silently skipping) on its automatic trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)